### PR TITLE
 feat: implement admin hierarchy UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ migrations/         # SQL migration files (versioned)
 
 **Module Refactoring:** The Building module is split to separate core CRUD (`building_repository.go`) from analytics (`building_repository_analytics.go`) to prevent code bloat.
 
-### Frontend (Angular) - Standalone Components
+### Frontend (Angular) - Standalone Components with Feature-Level State
 
 ```
 src/app/
@@ -141,18 +141,28 @@ src/app/
 │   └── models/      # Shared TypeScript interfaces
 ├── features/        # Feature modules by domain
 │   ├── [feature]/
-│   │   ├── [name].ts    # Standalone component (no .component suffix)
-│   │   ├── [name].html  # Template
-│   │   └── [name].scss  # Styles
+│   │   ├── [name].ts              # Standalone component (no .component suffix)
+│   │   ├── [name].html            # Template
+│   │   ├── [name].scss            # Styles with theme support
+│   │   ├── store/                 # Optional: Feature-specific NgRx store
+│   │   │   ├── [name].actions.ts
+│   │   │   ├── [name].reducer.ts
+│   │   │   ├── [name].selectors.ts
+│   │   │   └── [name].effects.ts
+│   │   └── ...
 │   └── ...
 ├── shared/          # Shared UI components, pipes
-├── store/           # NgRx store, effects, actions (global state)
+├── store/           # Global NgRx store, effects, actions
+│   ├── auth/        # Authentication state
+│   ├── app/         # Global app state
+│   └── ...
 └── app.routes.ts    # Route definitions
 ```
 
 **Key Patterns:**
 - Uses standalone components (no NgModule)
-- NgRx for global state management
+- Global state managed via NgRx in `src/app/store/`
+- Features can have their own NgRx stores (e.g., `features/properties/store/`) for feature-specific state
 - Services use RxJS observables
 - Material Design for UI components
 - Environment files for configuration
@@ -198,10 +208,100 @@ src/backend/notification-service/
 - HTTP interceptor attaches token to requests
 - Auth guard protects routes
 
-**Current Roles** (3-level system):
-- `Admin` - Full access
-- `PropertyManager` - Property-level operations
+**Current Roles & Multi-Tenancy** (3-level system):
+- `Admin` - Full access, organization-wide administration
+- `PropertyManager` - Property-level operations, building/unit management
 - `Accountant` - Read-only financial access
+- Multi-tenancy fully implemented with organization management and admin hierarchy
+
+---
+
+## 🎨 Frontend Styling & Theming
+
+### Theme System
+
+The frontend supports light and dark themes using **CSS variables**. This enables:
+- Runtime theme switching without reloads
+- Consistent color palettes across components
+- Easy maintenance of theme colors in one place
+
+**Theme Structure:**
+```scss
+// In component SCSS files:
+:root,
+[data-theme='light'] {
+  --bg-primary: #ffffff;
+  --text-primary: #1a1a1a;
+  --color-primary: #1e88e5;
+  // ... more variables
+}
+
+[data-theme='dark'] {
+  --bg-primary: #121212;
+  --text-primary: #ffffff;
+  --color-primary: #64b5f6;
+  // ... more variables
+}
+```
+
+**Using Theme Variables:**
+```scss
+.component {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.3s, color 0.3s; // Smooth theme transitions
+}
+```
+
+**Theme Switching (TypeScript):**
+```typescript
+toggleTheme(): void {
+  this.isDarkMode = !this.isDarkMode;
+  localStorage.setItem('theme', this.isDarkMode ? 'dark' : 'light');
+  document.documentElement.setAttribute('data-theme', this.isDarkMode ? 'dark' : 'light');
+}
+```
+
+**Examples**: See `dashboard.scss` and `property-card.scss` for comprehensive theme implementation.
+
+### Component Styling Guidelines
+
+When developing new Angular components:
+
+1. **Organize SCSS**:
+   - Group theme variables at the top
+   - Use mixins for reusable patterns
+   - Order: variables → mixins → base styles → responsive media queries
+
+2. **Use CSS Mixins for DRY Code**:
+   ```scss
+   @mixin card-style {
+     background-color: var(--bg-primary);
+     border: 1px solid var(--border-color);
+     border-radius: 12px;
+     box-shadow: var(--shadow-sm);
+   }
+   
+   .card { @include card-style; }
+   ```
+
+3. **Responsive Breakpoints**:
+   ```scss
+   @media (max-width: 768px) { /* Tablet */ }
+   @media (max-width: 480px) { /* Mobile */ }
+   ```
+
+4. **Animations**:
+   - Prefer CSS-only animations for performance
+   - Use `transition` for state changes (hover, focus)
+   - Use `@keyframes` for complex animations
+   - Example: See dashboard sparkline animations
+
+5. **Accessibility**:
+   - All interactive elements must have `:hover`, `:focus`, `:active` states
+   - Use `tabindex="0"` for custom interactive elements
+   - Provide `aria-label` for icon-only buttons
+   - Ensure color contrast meets WCAG AA standards (4.5:1 for text)
 
 ---
 
@@ -232,8 +332,12 @@ src/backend/notification-service/
 - `angular.json`, `tsconfig.json` - Frontend build config
 - `docker-compose.yml`, `docker-compose.dev.yml` - Container orchestration
 
+**Build Budgets** (Angular):
+- Component style budget: 18kB max error (updated from 6.5kB to accommodate feature-rich components)
+- Adjust in `angular.json` under `projects → tenantly-frontend → architect → build → configurations → production → budgets`
+
 ### Git Conventions (from CONTRIBUTING.md)
-- **Branch naming**: `feat/`, `fix/`, `chore/`, `docs/`, `test/` prefixes
+- **Branch naming**: `feat/`, `fix/`, `chore/`, `docs/`, `test/`, `topic/` prefixes
 - **Commits**: Conventional Commits format
   - Example: `feat(auth): add JWT middleware`
   - Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `style`, `perf`
@@ -241,13 +345,16 @@ src/backend/notification-service/
 ### Code Style
 - **Go**: Follow [Effective Go](https://go.dev/doc/effective_go), use `gofmt`
 - **Angular**: Follow [Angular Style Guide](https://angular.io/guide/styleguide), use Prettier + ESLint
+  - Component naming: No `.component` suffix for standalone components
+  - Use `[data-theme]` for theme-aware styling
+  - Prefer `signal()` and `computed()` over traditional change detection when possible
 - **C#**: Follow [Microsoft C# Conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
 
 ---
 
 ## 🔄 Development Workflow
 
-1. Create feature branch: `git checkout -b feat/feature-name`
+1. Create feature branch: `git checkout -b feat/feature-name` or `git checkout -b topic/##/feature-name`
 2. Make changes following conventions
 3. Run quality checks:
    - Backend: `go test ./internal/...`
@@ -265,7 +372,7 @@ src/backend/notification-service/
 - `src/backend/api/README.md` - Backend architecture details
 - `src/backend/api/AUTHENTICATION.md` - Auth implementation details
 - `src/frontend/README.md` - Frontend setup & conventions
-- `ADMIN_HIERARCHY_PLAN.md` - Upcoming multi-tenancy & role hierarchy implementation plan
+- `ADMIN_HIERARCHY_PLAN.md` - Multi-tenancy & role hierarchy implementation status
 
 ---
 
@@ -278,13 +385,29 @@ Available helper scripts in `scripts/` directory:
 
 ---
 
+## 🎯 Recent Enhancements (Reference Examples)
+
+### Dashboard Redesign
+- **Location**: `src/frontend/src/app/features/dashboard/`
+- **Features**: Financial metrics, collection rate progress ring, 6-month trend sparklines, light/dark theme support
+- **Reference for**: Theme implementation, SVG charts, progress indicators, staggered animations
+
+### Property Card Redesign
+- **Location**: `src/frontend/src/app/features/properties/property-card/`
+- **Features**: Visual hero section, quick stats bar, color-coded property types, responsive grid
+- **Reference for**: Component styling, color-coding patterns, responsive design, nested hierarchies
+
+---
+
 ## ⚠️ Common Issues & Notes
 
-- **Frontend**: Uses Angular 21 with standalone components (no NgModule)
+- **Frontend**: Uses Angular 21 with standalone components (no NgModule), signals for state management
 - **Backend**: Environment variables required (see `.env.example`)
 - **Database**: PostgreSQL must be running before API starts
 - **Node version**: Node 25+ required for frontend
 - **Go version**: Go 1.25+ required for backend
+- **SCSS Build Size**: Feature-rich components may exceed default style budgets; update `angular.json` if needed
+- **Theme Persistence**: Theme preference is stored in localStorage under key `dashboard-theme` or `theme`
 
 ---
 
@@ -294,3 +417,5 @@ Available helper scripts in `scripts/` directory:
 - **Gin Web Framework**: https://github.com/gin-gonic/gin
 - **PostgreSQL**: https://www.postgresql.org/docs/
 - **Docker Compose**: https://docs.docker.com/compose/
+- **Material Design**: https://material.angular.io/
+- **NgRx**: https://ngrx.io/docs

--- a/README.md
+++ b/README.md
@@ -1,65 +1,54 @@
-# 🏠 Tenantly - Property Rental Management System
+# Tenantly — Property Rental Management System
 
-A comprehensive tenant management system designed for the Bangladesh market, focusing on property rental management.
+A multi-tenant property management platform built for the Bangladesh market. Handles tenant onboarding, lease management, payment tracking, and automated billing across multiple organisations.
 
-## 📋 Overview
+## Services
 
-Tenantly is a robust, multi-service platform built to streamline property management. It handles everything from tenant onboarding and lease management to automated billing and notifications.
+| Service | Stack | Port |
+|---------|-------|------|
+| Backend API | Go (Gin) + PostgreSQL | 8080 |
+| Frontend | Angular + Material Design | 4200 |
+| Notification Service | .NET background worker | — |
 
-- **Backend API**: High-performance Go (Gin) service for core logic.
-- **Frontend**: Modern Angular application with a responsive dashboard.
-- **Notification Service**: Background worker built with .NET for SMS/Email alerts.
+## Quick Start
 
-## 🚀 Quick Start
+**Prerequisites:** Docker Desktop, Docker Compose
 
-The fastest way to get started is using Docker Compose.
+```bash
+cp .env.example .env
+docker-compose up -d
+```
 
-### 🛠️ Prerequisites
+- Frontend: http://localhost:4200
+- API: http://localhost:8080/api/v1
 
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
+For local development without Docker, see the component READMEs below.
 
-### ⚙️ Setup
+## Features
 
-1. **Clone the repository**
-2. **Setup environment variables**:
-   ```bash
-   cp .env.example .env
-   ```
-3. **Start the platform**:
-   ```bash
-   docker-compose up -d
-   ```
+- **Multi-Organisation** — Users belong to one or more organisations; login routes to an organisation picker when multiple are available, issuing organisation-scoped JWTs
+- **Role-Based Access** — Five roles: `SUPER_ADMIN`, `ORG_ADMIN`, `Admin`, `PropertyManager`, `Accountant`
+- **Property Management** — Buildings, units, occupancy tracking
+- **Tenant & Lease Management** — Profiles, lease terms, automated renewals
+- **Payment Tracking** — Multi-channel payment recording and reporting
+- **User Onboarding** — Token-based invitation workflow for new organisation members
+- **Admin Panel** — Organisation management, invitation management, and audit logs (SUPER_ADMIN / ORG_ADMIN)
+- **Notifications** — SMS and email reminders for rent due and lease renewals
+- **Localisation** — Bengali language support, BDT (৳) currency
 
-The applications will be available at:
-- **Frontend**: `http://localhost:4200`
-- **Backend API**: `http://localhost:8080/api/v1`
-- **PostgreSQL**: `localhost:5432`
+## Documentation
 
-## 📂 Project Structure
+| Component | README |
+|-----------|--------|
+| Backend API | [src/backend/api/README.md](./src/backend/api/README.md) |
+| Frontend | [src/frontend/README.md](./src/frontend/README.md) |
+| Notification Service | [src/backend/notification-service/README.md](./src/backend/notification-service/README.md) |
+| Authentication | [src/backend/api/AUTHENTICATION.md](./src/backend/api/AUTHENTICATION.md) |
 
-For detailed documentation, please refer to the specific component directories:
+## Contributing
 
-| Component | Description | Documentation |
-|-----------|-------------|---------------|
-| **Backend API** | Go REST API | [backend/api](./src/backend/api/README.md) |
-| **Notification Service** | .NET Background Service | [backend/notification-service](./src/backend/notification-service/README.md) |
-| **Frontend** | Angular Application | [frontend](./src/frontend/README.md) |
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, commit conventions, and the development workflow.
 
-## ✨ Features
+## License
 
-- **Property Management**: Track properties, buildings, units, and occupancy.
-- **Tenant Management**: Profiles, contact info, and history.
-- **Lease Processing**: Terms, deposits, and automated renewals.
-- **Payments**: Multi-channel payment tracking and invoicing.
-- **Automated Alerts**: SMS and Email reminders for rent and renewals.
-- **Localization**: Native support for Bengali and BDT (৳).
-- **CI/CD**: Automated linting, formatting, and deployment via GitHub Actions.
-
-## 🤝 Contributing
-
-Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started with development.
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE).

--- a/docs/AUDIT_LOGGING_ENHANCEMENT.md
+++ b/docs/AUDIT_LOGGING_ENHANCEMENT.md
@@ -1,0 +1,191 @@
+# Audit Logging Enhancement Plan
+
+**Status**: Future Enhancement (Post-Phase 3)
+**Priority**: Medium
+**Scope**: Observability & Compliance
+
+---
+
+## Overview
+
+Audit logging is currently stubbed in Phase 3 (Angular UI placeholder) with backend models and repository layer ready (Phase 1). This document outlines the strategy to enhance audit logging with a robust third-party service for production use.
+
+---
+
+## Current State (Phase 3)
+
+### Backend ✅
+- `AuditLog` model in `internal/models/audit_log.go`
+- Database schema with `audit_logs` table
+- Events captured: organization CRUD, user invitations, role changes
+- Local storage in PostgreSQL for legal/compliance requirements
+
+### Frontend 🚧
+- `audit-log.model.ts` - Interface definition
+- `audit-log.service.ts` - API client (stub)
+- `audit-log-viewer.ts` - Component (stub, no UI)
+- No audit log visualization in current app
+
+**Gap**: No UI to query/view audit logs; events only stored in DB
+
+---
+
+## Enhancement Strategy
+
+### Phase 1: Third-Party Integration (Future)
+
+**Recommended Service: Axiom.co**
+
+- **Why**: Generous free tier (25GB/month), excellent UI, easy REST API, perfect for audit trails
+- **Cost**: Free tier + pay-as-you-go ($0.34/GB after 25GB)
+- **Backup Options**: ELK Stack (self-hosted), Grafana Loki (lightweight)
+
+#### Integration Steps
+
+1. **Backend (Go)**
+   - Add Axiom client dependency
+   - Create `internal/services/audit_logger_service.go` to forward events
+   - Update audit event handlers to send to Axiom (async, non-blocking)
+   - Fallback: Always log to PostgreSQL first, Axiom as secondary
+
+2. **Configuration**
+   - Add to `.env`: `AXIOM_API_TOKEN`, `AXIOM_DATASET`, `AXIOM_API_URL`
+   - Feature flag: `ENABLE_AXIOM_AUDIT_LOGGING` (default: false)
+
+3. **Event Payload** (sent to Axiom)
+   ```json
+   {
+     "timestamp": "2026-04-01T10:30:00Z",
+     "organization_id": 1,
+     "user_id": 42,
+     "user_email": "admin@example.com",
+     "action": "ORGANIZATION_CREATED",
+     "resource_type": "organization",
+     "resource_id": 5,
+     "resource_name": "Acme Corp",
+     "ip_address": "203.0.113.45",
+     "status": "success",
+     "changes": { "name": "Acme Corp", "subscription_tier": "professional" }
+   }
+   ```
+
+---
+
+### Phase 2: UI Enhancement (Post-Phase 3)
+
+**Before Phase 4 (acceptance invitations)**
+
+1. **Update `audit-log-viewer.ts` Component**
+   - Replace stub with real MatTable implementation
+   - Columns: Timestamp, User Email, Action, Resource Type, Resource Name, Status
+   - Filters: Action type dropdown, date range picker, user email search
+   - Pagination: 50 events per page
+   - Expandable rows for full `changes` JSON payload
+
+2. **Two Data Sources** (Configurable)
+   - **Local (PostgreSQL)**: Always available, faster queries
+   - **Remote (Axiom)**: When enabled, more advanced analytics/retention
+
+3. **Service Updates**
+   ```typescript
+   // audit-log.service.ts
+   getAuditLogs(orgId, filters?)
+     // Queries PostgreSQL by default
+     // Falls back to Axiom if `useRemote` flag set
+
+   exportAuditLogs(orgId)
+     // CSV export from local DB
+     // Option to export from Axiom (30-day window)
+   ```
+
+---
+
+## Implementation Timeline
+
+| Phase | Task | Timeline | Owner |
+|-------|------|----------|-------|
+| Phase 3 (Current) | Models & stubs | Complete ✅ | Done |
+| Phase 4 | Axiom integration (Go backend) | Month 2 | Backend |
+| Phase 4+ | UI implementation (Angular) | Month 2-3 | Frontend |
+| Phase 5+ | Advanced analytics dashboard | Month 4+ | Frontend |
+
+---
+
+## Service Comparison
+
+| Service | Type | Free Tier | Retention | UI | Setup |
+|---------|------|-----------|-----------|----|----|
+| **Axiom.co** | Cloud | 25GB/month | 14 days | ⭐⭐⭐⭐⭐ | Easy |
+| **ELK Stack** | Self-Hosted | Unlimited | Configurable | ⭐⭐⭐⭐ | Medium |
+| **Grafana Loki** | Self-Hosted | Unlimited | Configurable | ⭐⭐⭐ | Hard |
+| **Datadog** | Cloud | 5GB/day | 3 days | ⭐⭐⭐⭐⭐ | Easy |
+
+**Recommendation**: Start with Axiom (Phase 4), migrate to ELK if self-hosted becomes requirement.
+
+---
+
+## Database Retention Strategy
+
+### Current (PostgreSQL)
+- Keep all audit logs indefinitely (compliance requirement)
+- Monthly archive to cold storage (S3/GCS) for logs older than 90 days
+- Indexed on `organization_id`, `created_at` for fast queries
+
+### With Axiom
+- Forward to Axiom (14-day retention)
+- PostgreSQL remains source of truth (permanent record)
+- Axiom UI for recent audits, DB queries for historical
+
+---
+
+## Security & Compliance
+
+- ✅ No PII in audit logs (except email for user context)
+- ✅ Logs immutable (append-only in DB)
+- ✅ Access control: Only ORG_ADMIN+ can view org's audit logs
+- ✅ Encryption: HTTPS to Axiom, PostgreSQL SSL connections
+- ✅ GDPR: Implement data retention policy (e.g., auto-delete after 7 years)
+
+---
+
+## File References
+
+**Backend (Phase 1, Complete)**
+- `internal/models/audit_log.go` - Model definition
+- `internal/repositories/audit_log_repository.go` - Database access
+- `internal/models/audit_log.go` - Structs
+- `migrations/000007_admin_hierarchy_phase1.up.sql` - Schema
+
+**Frontend (Phase 3, Stubs)**
+- `src/frontend/src/app/core/models/audit-log.model.ts` - TS interface
+- `src/frontend/src/app/core/services/audit-log.service.ts` - API client
+- `src/frontend/src/app/features/admin/audit-logs/audit-log-viewer.ts` - Component stub
+
+**Future Work**
+- `internal/services/audit_logger_service.go` - Axiom integration
+- `src/frontend/src/app/features/admin/audit-logs/audit-log-viewer.html` - Template
+- `src/frontend/src/app/features/admin/audit-logs/audit-log-viewer.spec.ts` - Tests
+
+---
+
+## Success Criteria
+
+- [ ] Axiom integration compiles without errors
+- [ ] Audit events forward to Axiom (configurable, off by default)
+- [ ] PostgreSQL audit log table remains primary record
+- [ ] UI component displays 50+ events with filtering & sorting
+- [ ] Expandable rows show full change payloads
+- [ ] Export to CSV includes timestamp, user, action, resource, status
+- [ ] Performance: Audit log queries < 500ms for 90-day window
+- [ ] All unit tests pass (new + existing)
+
+---
+
+## Notes
+
+- Axiom API token must be secrets-managed (not in repo)
+- Async logging: Don't block requests on Axiom failures
+- Consider alerting if audit logging fails silently
+- Plan for GDPR right-to-be-forgotten: implement audit log deletion workflow
+- Monitor Axiom costs as event volume grows (scale to ELK if needed)
+

--- a/src/backend/api/README.md
+++ b/src/backend/api/README.md
@@ -1,91 +1,90 @@
 # Tenantly Backend API
 
-The backend for the Tenantly property management platform, built with Go (Golang).
+Go REST API for the Tenantly platform, built with Gin.
 
-## 🏗 Project Architecture
+## Tech Stack
 
-This project follows a modular, layer-based architecture designed for scalability and maintainability.
+- **Language**: Go 1.25+
+- **Framework**: [Gin](https://github.com/gin-gonic/gin)
+- **Database**: PostgreSQL (`lib/pq`, raw SQL)
+- **Auth**: JWT access tokens + refresh tokens (bcrypt password hashing, cost 12)
+- **Migrations**: `golang-migrate` — versioned SQL files in `migrations/`
+- **Dev server**: `air` (hot reload via `.air.toml`)
 
-### Directory Structure
-
-```text
-src/backend/api/
-├── cmd/                    # Entry points for the application
-├── internal/               # Private application code
-│   ├── models/             # Domain entities and data structures
-│   ├── repositories/       # Database access layer (DAO)
-│   ├── services/           # Business logic and use cases
-│   ├── handlers/           # HTTP handlers (Controllers)
-│   ├── middleware/         # HTTP middleware (Auth, Logging, etc.)
-│   └── database/           # Database connection and migration tools
-├── migrations/             # SQL migration files
-└── go.mod                  # Dependencies
-```
-
-## 🚀 Recent Refactoring & Improvements
-
-### Building Module Optimization
-
-To address code bloat and improve maintainability, the Building module has been refactored to separate **Core Domain Logic** from **Analytics & Reporting**.
-
-*   **Models Split**:
-    *   `models/building.go`: Contains the core `Building` entity and basic CRUD structures.
-    *   `models/building_analytics.go`: Contains complex analytics structures like `BuildingMetrics`, `RevenueAnalytics`, and `OccupancyAnalytics`.
-
-*   **Repositories Split**:
-    *   `repositories/building_repository.go`: Handles standard CRUD operations (Create, Read, Update, Delete) and search.
-    *   `repositories/building_repository_analytics.go`: Handles heavy aggregation queries and statistical data retrieval.
-
-This separation ensures that core operational logic remains lightweight while complex analytical processing is isolated.
-
-## 🛠 Tech Stack
-
-*   **Language**: Go 1.25+
-*   **Web Framework**: [Gin Gonic](https://github.com/gin-gonic/gin)
-*   **Database**: PostgreSQL (using `lib/pq` driver)
-*   **Authentication**: JWT (JSON Web Tokens)
-*   **Migrations**: `golang-migrate`
-*   **Testing**: `testify`
-
-## 🏃‍♂️ Getting Started
-
-### Prerequisites
-
-*   Go 1.25+
-*   PostgreSQL running locally or via Docker
-
-### Manual Setup (Local)
-
-1.  **Configure Environment**:
-    ```bash
-    cp .env.example .env
-    ```
-2.  **Install Dependencies**:
-    ```bash
-    go mod download
-    ```
-3.  **Run Migrations**:
-    ```bash
-    # Ensure DB_URL is set in .env
-    go run cmd/server/main.go migrate
-    ```
-4.  **Start Server**:
-    ```bash
-    go run cmd/server/main.go
-    ```
-
-### Running Tests
-
-To run all tests in the internal directory:
+## Getting Started
 
 ```bash
-cd src/backend/api
+cp .env.example .env          # configure DB_URL and JWT_SECRET
+go mod download
+go run cmd/server/main.go migrate
+go run cmd/server/main.go     # or: air
+```
+
+API is available at `http://localhost:8080/api/v1`.
+
+## Project Structure
+
+```
+internal/
+├── models/        # Domain structs + request/response types with JSON tags
+├── repositories/  # DB access layer (raw SQL, lib/pq)
+├── services/      # Business logic; depends only on repository interfaces
+├── handlers/      # HTTP handlers; depends only on service interfaces
+├── interfaces/    # All interface definitions in one file: interfaces.go
+├── middleware/    # JWT auth, logging, CORS
+├── config/        # Environment loading
+├── database/      # Connection pool + migration runner
+└── testutil/      # Shared mocks for table-driven tests
+
+cmd/server/        # Entry point
+migrations/        # 000NNN_description.up.sql + .down.sql pairs
+```
+
+### Dependency Injection
+
+All cross-layer dependencies are defined as interfaces in `internal/interfaces/interfaces.go`. Handlers receive service interfaces; services receive repository interfaces. Never inject concrete types across layers — wire them in `cmd/server/main.go`.
+
+### Building Module Split
+
+The Building module separates concerns across two repository files to prevent bloat:
+- `building_repository.go` — CRUD and search
+- `building_repository_analytics.go` — heavy aggregation queries, metrics, forecasting
+
+Apply the same pattern to any module that develops significant analytical queries.
+
+## Multi-Tenancy
+
+Migration `000007_admin_hierarchy_phase1` added `organization_id` to every data table (`users`, `properties`, `buildings`, `units`, `tenants`, `leases`, `payments`). All repository queries must be scoped by `organization_id`.
+
+Migration `000008_user_organization_roles` introduced the `user_organization_roles` table — a user can belong to multiple organisations with different roles.
+
+### Role System
+
+| Role | Description |
+|------|-------------|
+| `SUPER_ADMIN` | Cross-org platform administration |
+| `ORG_ADMIN` | Organisation-wide administration |
+| `Admin` | Operational admin within an org |
+| `PropertyManager` | Property/building/unit management |
+| `Accountant` | Read-only financial access |
+
+JWT claims include `user_id`, `username`, `role`, and `organization_id`. The `POST /auth/set-organization` endpoint issues a new token scoped to the requested organisation (validates membership via `user_organization_roles`).
+
+### Password Policy
+
+Enforced in `UserService.ValidatePassword`: 8–128 chars, at least one uppercase, lowercase, digit, and special character (`!@#$%^&*()_+-=[]{}';:"\\|,.<>/?`).
+
+## Testing
+
+```bash
+# All tests
 go test -v ./internal/...
+
+# Specific package
+go test -v ./internal/services/...
+
+# Single test by name
+go test -v ./internal/services/ -run TestLogin
 ```
 
-To run a specific test suite (e.g., Building Repository):
-
-```bash
-cd src/backend/api
-go test -v ./internal/repositories/...
-```
+Tests are table-driven. Mocks for all interfaces live in `internal/testutil/` — use those rather than creating per-test fakes.

--- a/src/backend/api/internal/handlers/building_handler_comprehensive_integration_test.go
+++ b/src/backend/api/internal/handlers/building_handler_comprehensive_integration_test.go
@@ -103,7 +103,7 @@ func (suite *BuildingIntegrationTestSuite) SetupTest() {
 func (suite *BuildingIntegrationTestSuite) setupTestRoutes(userHandler *UserHandler, propertyHandler *PropertyHandler, auditService *database.AuditService) {
 	// Add middleware
 	suite.router.Use(middleware.SecurityHeadersMiddleware())
-	suite.router.Use(middleware.CORS("test"))
+	suite.router.Use(middleware.CORS(suite.config.Environment))
 	suite.router.Use(gin.Logger())
 	suite.router.Use(gin.Recovery())
 

--- a/src/backend/api/internal/handlers/user_handler_test.go
+++ b/src/backend/api/internal/handlers/user_handler_test.go
@@ -89,6 +89,30 @@ func (m *MockUserService) DeleteUser(id int) error {
 	return args.Error(0)
 }
 
+func (m *MockUserService) GetUserByIDInOrganization(userID int, orgID int) (*models.User, error) {
+	args := m.Called(userID, orgID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
+func (m *MockUserService) RegisterWithInvitation(req *models.RegisterWithInvitationRequest) (*models.LoginResponse, error) {
+	args := m.Called(req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.LoginResponse), args.Error(1)
+}
+
+func (m *MockUserService) GetUsersByOrganization(orgID int) ([]*models.User, error) {
+	args := m.Called(orgID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.User), args.Error(1)
+}
+
 func setupTestRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	return gin.New()
@@ -251,8 +275,113 @@ func TestUserHandler_RefreshToken(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &response)
 		assert.NoError(t, err)
 		assert.Equal(t, loginResponse.Token, response.Token)
+		assert.Equal(t, loginResponse.RefreshToken, response.RefreshToken)
+		assert.NotEqual(t, req.RefreshToken, response.RefreshToken)
 
 		mockService.AssertExpectations(t)
+	})
+
+	t.Run("Invalid refresh token", func(t *testing.T) {
+		req := &models.RefreshTokenRequest{
+			RefreshToken: "invalid-refresh-token",
+		}
+
+		mockService.On("RefreshToken", "invalid-refresh-token").Return(nil, assert.AnError)
+
+		reqBody, _ := json.Marshal(req)
+		w := httptest.NewRecorder()
+		httpReq, _ := http.NewRequest("POST", "/auth/refresh", bytes.NewBuffer(reqBody))
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		router.ServeHTTP(w, httpReq)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "TOKEN_REFRESH_FAILED", response["code"])
+
+		mockService.AssertExpectations(t)
+	})
+
+	t.Run("Missing refresh token", func(t *testing.T) {
+		req := &models.RefreshTokenRequest{
+			RefreshToken: "",
+		}
+
+		reqBody, _ := json.Marshal(req)
+		w := httptest.NewRecorder()
+		httpReq, _ := http.NewRequest("POST", "/auth/refresh", bytes.NewBuffer(reqBody))
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		router.ServeHTTP(w, httpReq)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "INVALID_REQUEST", response["code"])
+	})
+
+	t.Run("Malformed JSON", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		httpReq, _ := http.NewRequest("POST", "/auth/refresh", bytes.NewBuffer([]byte("invalid json")))
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		router.ServeHTTP(w, httpReq)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestUserHandler_Logout(t *testing.T) {
+	mockService := new(MockUserService)
+	handler := NewUserHandler(mockService)
+	router := setupTestRouter()
+
+	// Middleware to set user context
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", 1)
+		c.Next()
+	})
+
+	router.POST("/auth/logout", handler.Logout)
+
+	t.Run("Success", func(t *testing.T) {
+		mockService.On("Logout", 1, "", "").Return(nil)
+
+		w := httptest.NewRecorder()
+		httpReq, _ := http.NewRequest("POST", "/auth/logout", nil)
+
+		router.ServeHTTP(w, httpReq)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "Successfully logged out", response["message"])
+
+		mockService.AssertExpectations(t)
+	})
+
+	t.Run("Logout without authentication", func(t *testing.T) {
+		router2 := setupTestRouter()
+		router2.POST("/auth/logout", handler.Logout)
+
+		w := httptest.NewRecorder()
+		httpReq, _ := http.NewRequest("POST", "/auth/logout", nil)
+
+		router2.ServeHTTP(w, httpReq)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "NOT_AUTHENTICATED", response["code"])
 	})
 }
 

--- a/src/backend/api/internal/middleware/auth_test.go
+++ b/src/backend/api/internal/middleware/auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,7 +17,7 @@ func TestAuthRequired(t *testing.T) {
 
 	jwtSecret := "test-secret"
 
-	// Create a test token
+	// Create a valid test token
 	claims := jwt.MapClaims{
 		"user_id":  1,
 		"username": "testuser",
@@ -28,30 +29,67 @@ func TestAuthRequired(t *testing.T) {
 	tokenString, err := token.SignedString([]byte(jwtSecret))
 	assert.NoError(t, err)
 
+	// Create an expired token
+	expiredClaims := jwt.MapClaims{
+		"user_id":  1,
+		"username": "testuser",
+		"role":     "Admin",
+		"exp":      time.Now().Add(-time.Hour).Unix(),
+	}
+	expiredToken := jwt.NewWithClaims(jwt.SigningMethodHS256, expiredClaims)
+	expiredTokenString, _ := expiredToken.SignedString([]byte(jwtSecret))
+
+	// Create token with wrong secret
+	wrongSecretToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	wrongSecretTokenString, _ := wrongSecretToken.SignedString([]byte("wrong-secret"))
+
 	tests := []struct {
 		name           string
 		authHeader     string
 		expectedStatus int
+		expectedCode   string
 	}{
 		{
 			name:           "Valid token",
 			authHeader:     "Bearer " + tokenString,
 			expectedStatus: http.StatusOK,
+			expectedCode:   "",
 		},
 		{
 			name:           "No auth header",
 			authHeader:     "",
 			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   "AUTH_HEADER_MISSING",
 		},
 		{
-			name:           "Invalid token format",
+			name:           "Invalid token format (missing Bearer)",
 			authHeader:     "InvalidToken",
 			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   "INVALID_TOKEN_FORMAT",
 		},
 		{
-			name:           "Invalid token",
+			name:           "Malformed JWT",
 			authHeader:     "Bearer invalid.token.here",
 			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   "TOKEN_INVALID",
+		},
+		{
+			name:           "Expired token",
+			authHeader:     "Bearer " + expiredTokenString,
+			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   "TOKEN_INVALID",
+		},
+		{
+			name:           "Token signed with wrong secret",
+			authHeader:     "Bearer " + wrongSecretTokenString,
+			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   "TOKEN_INVALID",
+		},
+		{
+			name:           "Empty Bearer token",
+			authHeader:     "Bearer ",
+			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   "TOKEN_INVALID",
 		},
 	}
 
@@ -60,6 +98,11 @@ func TestAuthRequired(t *testing.T) {
 			router := gin.New()
 			router.Use(AuthRequired(jwtSecret, nil))
 			router.GET("/test", func(c *gin.Context) {
+				// Verify context is populated with user info
+				userID, exists := c.Get("user_id")
+				if exists {
+					assert.NotNil(t, userID)
+				}
 				c.JSON(http.StatusOK, gin.H{"message": "success"})
 			})
 
@@ -72,8 +115,65 @@ func TestAuthRequired(t *testing.T) {
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if tt.expectedCode != "" {
+				var response map[string]string
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedCode, response["code"])
+			}
 		})
 	}
+}
+
+func TestAuthRequiredContextPopulation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	jwtSecret := "test-secret"
+
+	claims := jwt.MapClaims{
+		"user_id":  42,
+		"username": "testuser",
+		"role":     "Admin",
+		"exp":      time.Now().Add(time.Hour).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte(jwtSecret))
+
+	t.Run("Valid token populates all context fields", func(t *testing.T) {
+		router := gin.New()
+		router.Use(AuthRequired(jwtSecret, nil))
+		router.GET("/test", func(c *gin.Context) {
+			userID, exists := c.Get("user_id")
+			assert.True(t, exists, "user_id should exist in context")
+
+			// user_id is stored as int in context (converted from float64 by middleware)
+			userIDVal, ok := userID.(int)
+			assert.True(t, ok, "user_id should be int")
+			assert.Equal(t, 42, userIDVal)
+
+			username, exists := c.Get("username")
+			assert.True(t, exists, "username should exist in context")
+			assert.Equal(t, "testuser", username)
+
+			role, exists := c.Get("role")
+			assert.True(t, exists, "role should exist in context")
+			assert.Equal(t, "Admin", role)
+
+			c.JSON(http.StatusOK, gin.H{
+				"message": "success",
+			})
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenString)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
 }
 
 func TestRequireRole(t *testing.T) {

--- a/src/backend/api/internal/server/server.go
+++ b/src/backend/api/internal/server/server.go
@@ -78,7 +78,6 @@ func (s *Server) setupRoutes() {
 	buildingService := services.NewBuildingService(buildingRepo, propertyRepo, auditService, metadataValidator)
 	unitService := services.NewUnitService(unitRepo, buildingRepo, propertyRepo, auditService)
 	tenantService := services.NewTenantService(tenantRepo, auditService)
-
 	// Initialize handlers
 	userHandler := handlers.NewUserHandler(userService)
 	propertyHandler := handlers.NewPropertyHandler(propertyService)

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -1,91 +1,114 @@
 # Tenantly Frontend
 
-The frontend for the Tenantly property management platform, built with modern Angular.
+Angular application for the Tenantly platform.
 
-## 🛠 Tech Stack
+## Tech Stack
 
-- **Framework**: Angular 20+ (standalone components)
+- **Framework**: Angular 21 (standalone components, no NgModule)
 - **Language**: TypeScript
-- **Styling**: SCSS, Material Design
-- **State Management**: NgRx (Store, Effects, Entity)
-- **Build Tool**: Vite (Internal Dev Server) / esbuild (Build)
+- **UI**: Angular Material (Material Design 3)
+- **State**: NgRx (Store, Effects, Selectors)
+- **Styling**: SCSS with CSS custom properties for light/dark theming
+- **Build**: esbuild / Vite dev server
 
-## 📁 Project Structure
-
-```text
-src/frontend/
-├── src/
-│   ├── app/              # Application core
-│   │   ├── core/         # Services, guards, interceptors (Singleton logic)
-│   │   ├── features/     # Feature modules (Business domains)
-│   │   │   └── [feature]/
-│   │   │       ├── [name].ts    # Standalone Component (Logic)
-│   │   │       ├── [name].html  # Template
-│   │   │       └── [name].scss  # Styles
-│   │   └── shared/       # Shared UI components and pipes
-│   ├── assets/           # Static assets
-│   └── environments/     # Environment configurations
-├── public/               # Public assets
-└── angular.json          # Angular workspace configuration
-```
-
-## 📐 Component Conventions
-
-Following modern Angular 20+ patterns:
-- **Standalone Components**: No `NgModule` required.
-- **File Naming**: Component files use the format `[name].ts` (without the `.component` suffix for the filename, e.g., `login.ts`).
-- **External Templates**: Always use `templateUrl` and `styleUrls` to maintain clean separation.
-
-## 🚀 Getting Started
-
-### Prerequisites
-
-- Node.js 25+
-- npm 10+
-- Angular CLI (`npm install -g @angular/cli`)
-
-### Local Development
+## Getting Started
 
 ```bash
 cd src/frontend
-npm install
-npm start
+npm ci
+npm run start:local       # http://localhost:4200
+npm run start:network     # http://0.0.0.0:4200 (LAN access)
 ```
-The app will be available at `http://localhost:4200`.
 
-### Building for Production
+**Prerequisites**: Node.js 25+, npm 10+
+
+## Project Structure
+
+```
+src/app/
+├── core/
+│   ├── guards/        # AuthGuard (class), orgAdminGuard, superAdminGuard (functional)
+│   ├── interceptors/  # HTTP auth interceptor — attaches token, handles 401 with refresh
+│   ├── models/        # Shared TypeScript interfaces (re-exported from core/models/index.ts)
+│   └── services/      # AuthService, OrganizationService, PermissionService
+├── features/          # One directory per domain; components use [name].ts (no .component suffix)
+│   ├── auth/          # login, organization-picker
+│   ├── admin/         # organization-management, user-onboarding, audit-logs
+│   └── [domain]/      # Optional store/ sub-directory for feature-level NgRx
+├── shared/            # Reusable UI components (OrganizationSelector)
+└── store/
+    └── auth/          # Global auth state: actions, reducer, effects, selectors, facade
+```
+
+Feature-level NgRx stores (e.g. `features/properties/store/`) are provided lazily via `provideState`/`provideEffects` in route config, not registered globally.
+
+## Auth & Multi-Organisation Flow
+
+After a successful login the API returns `organizations[]` and an optional `default_organization_id`:
+
+- **Multiple orgs, no default** → navigate to `/select-organization` (org picker)
+- **Single org or default set** → store org context and navigate to `/dashboard`
+
+Selecting an organisation calls `POST /auth/set-organization`, which returns a new org-scoped JWT. The token and org context are stored in `localStorage` and restored on page refresh by `initializeFromStorage()` (runs at module load) and the `initializeAuth` NgRx action.
+
+### localStorage Keys
+
+| Key | Content |
+|-----|---------|
+| `tenantly_token` | JWT access token |
+| `tenantly_refresh_token` | Refresh token |
+| `tenantly_user` | Serialised `User` object |
+| `tenantly_expires_at` | ISO expiry string |
+| `tenantly_organizations` | Full `UserOrganizationRole[]` array |
+| `tenantly_current_org_id` | Active `organization_id` (FK to `organizations` table) |
+| `tenantly_current_org` | Active `UserOrganizationRole` object |
+
+Always use `org.organization_id` (not `org.id`) when identifying the current organisation.
+
+## Route Guards
+
+| Guard | Allows |
+|-------|--------|
+| `AuthGuard` | Any authenticated user |
+| `orgAdminGuard` | `SUPER_ADMIN` or `ORG_ADMIN` |
+| `superAdminGuard` | `SUPER_ADMIN` only |
+
+`/admin/*` routes require `orgAdminGuard`. `/admin/organizations/*` additionally require `superAdminGuard`.
+
+## Theming
+
+Components use CSS custom properties scoped to `[data-theme]` on `:root`:
+
+```scss
+:root, [data-theme='light'] { --bg-primary: #ffffff; }
+[data-theme='dark']         { --bg-primary: #121212; }
+
+.card { background: var(--bg-primary); }
+```
+
+See `dashboard.scss` for a complete example. The component style budget is 18 kB (configured in `angular.json`).
+
+## Quality & Testing
 
 ```bash
+npm run quality            # Prettier + ESLint fix
+npm run lint               # Lint only
+npm run format:check       # CI formatting check
+
+npm test                   # All unit tests (Karma/Jasmine, watch mode)
+
+# Run a specific spec file without watch
+npm test -- --include="**/store/auth/*.spec.ts" --watch=false
+
 npm run build
 ```
-The build artifacts will be stored in the `dist/` directory.
 
-## 🧪 Testing
+### Test Patterns
 
-```bash
-# Run unit tests
-npm test
+- **Reducers**: call `reducer(state, action)` directly
+- **Effects**: use `provideMockActions` + `HttpTestingController`; spy on `isDemoMode` for demo-mode branches
+- **Selectors**: call `selector.projector(mockState)` directly — no store setup needed
 
-# Run e2e tests
-npm run e2e
-```
+## CI
 
-## 🎨 Formatting & Quality
-
-```bash
-# Apply Prettier formatting
-npm run format
-
-# Run ESLint
-npm run lint
-
-# Check formatting (used in CI)
-npm run format:check
-```
-
-## 🏗 CI/CD
-
-This project uses GitHub Actions for Continuous Integration. Every push and pull request triggers the `Frontend CI` workflow, which ensures:
-- All dependencies can be installed (`npm ci`).
-- The code passes linting checks (`npm run lint`).
-- The code follows formatting standards (`npm run format:check`).
+GitHub Actions runs `npm ci`, `npm run lint`, and `npm run format:check` on every push and pull request.

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",
+    "start": "ng serve",
     "start:network": "ng serve --host 0.0.0.0 --port 4200",
     "start:local": "ng serve",
     "build": "ng build",

--- a/src/frontend/src/app/app.html
+++ b/src/frontend/src/app/app.html
@@ -82,9 +82,39 @@
           <mat-icon>folder</mat-icon>
           <span>Documents</span>
         </a>
-        } @if (canManageUsers()) {
+        } @if (canManageUsers() || isSuperAdmin() || isOrgAdmin()) {
         <mat-divider></mat-divider>
-
+        } @if (canManageOrganizations()) {
+        <a
+          mat-list-item
+          routerLink="/admin/organizations"
+          routerLinkActive="active"
+          (click)="onNavigate()"
+        >
+          <mat-icon>apartment</mat-icon>
+          <span>Organizations</span>
+        </a>
+        } @if (canInviteUsers()) {
+        <a
+          mat-list-item
+          routerLink="/admin/invitations"
+          routerLinkActive="active"
+          (click)="onNavigate()"
+        >
+          <mat-icon>mail_outline</mat-icon>
+          <span>Invitations</span>
+        </a>
+        } @if (isOrgAdmin() || isSuperAdmin()) {
+        <a
+          mat-list-item
+          routerLink="/admin/audit-logs"
+          routerLinkActive="active"
+          (click)="onNavigate()"
+        >
+          <mat-icon>history</mat-icon>
+          <span>Audit Logs</span>
+        </a>
+        } @if (canManageUsers()) {
         <a mat-list-item routerLink="/users" routerLinkActive="active" (click)="onNavigate()">
           <mat-icon>admin_panel_settings</mat-icon>
           <span>Users</span>

--- a/src/frontend/src/app/app.routes.ts
+++ b/src/frontend/src/app/app.routes.ts
@@ -1,5 +1,7 @@
 import { Routes } from '@angular/router';
 import { AuthGuard } from './core/guards/auth.guard';
+import { superAdminGuard } from './core/guards/super-admin.guard';
+import { orgAdminGuard } from './core/guards/org-admin.guard';
 import { provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 import { propertyReducer } from './features/properties/store/property.reducer';
@@ -73,6 +75,75 @@ export const routes: Routes = [
     path: 'users',
     loadComponent: () => import('./features/users/user-list/user-list').then((m) => m.UserList),
     canActivate: [AuthGuard],
+  },
+  {
+    path: 'admin',
+    canActivate: [AuthGuard, orgAdminGuard],
+    children: [
+      {
+        path: 'organizations',
+        loadComponent: () =>
+          import('./features/admin/organization-management/organization-list').then(
+            (m) => m.OrganizationListComponent
+          ),
+        canActivate: [superAdminGuard],
+      },
+      {
+        path: 'organizations/new',
+        loadComponent: () =>
+          import('./features/admin/organization-management/organization-create').then(
+            (m) => m.OrganizationCreateComponent
+          ),
+        canActivate: [superAdminGuard],
+      },
+      {
+        path: 'organizations/:id',
+        loadComponent: () =>
+          import('./features/admin/organization-management/organization-detail').then(
+            (m) => m.OrganizationDetailComponent
+          ),
+        canActivate: [superAdminGuard],
+      },
+      {
+        path: 'organizations/:id/edit',
+        loadComponent: () =>
+          import('./features/admin/organization-management/organization-edit').then(
+            (m) => m.OrganizationEditComponent
+          ),
+        canActivate: [superAdminGuard],
+      },
+      {
+        path: 'invitations',
+        loadComponent: () =>
+          import('./features/admin/user-onboarding/pending-invitations').then(
+            (m) => m.PendingInvitationsComponent
+          ),
+      },
+      {
+        path: 'invitations/new',
+        loadComponent: () =>
+          import('./features/admin/user-onboarding/invite-user').then((m) => m.InviteUserComponent),
+      },
+      {
+        path: 'invitations/bulk',
+        loadComponent: () =>
+          import('./features/admin/user-onboarding/bulk-import').then((m) => m.BulkImportComponent),
+      },
+      {
+        path: 'audit-logs',
+        loadComponent: () =>
+          import('./features/admin/audit-logs/audit-log-viewer').then(
+            (m) => m.AuditLogViewerComponent
+          ),
+      },
+      {
+        path: 'users/promote',
+        loadComponent: () =>
+          import('./features/admin/user-management/admin-promotion').then(
+            (m) => m.AdminPromotionComponent
+          ),
+      },
+    ],
   },
   // Legacy routes for backward compatibility
   {

--- a/src/frontend/src/app/app.ts
+++ b/src/frontend/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, ViewChild, signal, computed, OnDestroy } from '@angular/core';
+import { Component, inject, OnInit, ViewChild, signal, computed } from '@angular/core';
 
 import { RouterOutlet, RouterModule } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -14,6 +14,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AuthFacade } from './store/auth/auth.facade';
 import { PermissionService } from './core/services/permission.service';
 import { Permission } from './core/models/role.model';
+import { User } from './core/services/auth.service';
 
 @Component({
   selector: 'app-root',
@@ -43,16 +44,20 @@ export class App implements OnInit {
   // Signals for reactive state
   isAuthenticated = signal(false);
   userRole = signal('');
-  user = signal<any>(null);
+  user = signal<User | null>(null);
   isMobile = signal(false);
 
   // Computed permission signals
+  isSuperAdmin = computed(() => this.permissions.isSuperAdmin());
+  isOrgAdmin = computed(() => this.permissions.isOrgAdmin());
   canManageProperties = computed(() =>
     this.permissions.hasPermission(Permission.MANAGE_PROPERTIES)
   );
   canManageTenants = computed(() => this.permissions.hasPermission(Permission.MANAGE_TENANTS));
   canManageDocuments = computed(() => this.permissions.hasPermission(Permission.MANAGE_DOCUMENTS));
   canManageUsers = computed(() => this.permissions.hasPermission(Permission.MANAGE_USERS));
+  canManageOrganizations = computed(() => this.permissions.canManageOrganizations());
+  canInviteUsers = computed(() => this.permissions.canInviteUsers());
 
   // Computed signals for derived state
   sidenavMode = computed(() => (this.isMobile() ? ('over' as const) : ('side' as const)));

--- a/src/frontend/src/app/core/guards/auth.guard.ts
+++ b/src/frontend/src/app/core/guards/auth.guard.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { AuthFacade } from '../../store/auth/auth.facade';
 

--- a/src/frontend/src/app/core/guards/org-admin.guard.spec.ts
+++ b/src/frontend/src/app/core/guards/org-admin.guard.spec.ts
@@ -1,0 +1,191 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { of, throwError } from 'rxjs';
+import { orgAdminGuard } from './org-admin.guard';
+
+describe('orgAdminGuard', () => {
+  let store: jasmine.SpyObj<Store>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    const storeSpy = jasmine.createSpyObj('Store', ['select']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Store, useValue: storeSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    store = TestBed.inject(Store) as jasmine.SpyObj<Store>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+  });
+
+  it('should allow access for SUPER_ADMIN user', (done) => {
+    store.select.and.returnValues(of(true), of(false)); // isSuperAdmin=true, isOrgAdmin=false
+
+    const guard = orgAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(true);
+      expect(router.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should allow access for ORG_ADMIN user', (done) => {
+    store.select.and.returnValues(of(false), of(true)); // isSuperAdmin=false, isOrgAdmin=true
+
+    const guard = orgAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(true);
+      expect(router.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should allow access for both SUPER_ADMIN and ORG_ADMIN', (done) => {
+    store.select.and.returnValues(of(true), of(true)); // both true
+
+    const guard = orgAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(true);
+      expect(router.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should deny access and navigate for non-admin user', (done) => {
+    store.select.and.returnValues(of(false), of(false)); // both false
+
+    const guard = orgAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(false);
+      expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+      done();
+    });
+  });
+
+  it('should deny access and navigate for Admin user', (done) => {
+    store.select.and.returnValues(of(false), of(false));
+
+    const guard = orgAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(false);
+      expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+      done();
+    });
+  });
+
+  it('should select both isSuperAdmin and isOrgAdmin from store', (done) => {
+    store.select.and.returnValues(of(true), of(false));
+
+    const guard = orgAdminGuard();
+    guard.subscribe(() => {
+      expect(store.select).toHaveBeenCalledTimes(2);
+      done();
+    });
+  });
+
+  it('should use take(1) operator to complete immediately', (done) => {
+    store.select.and.returnValues(of(true), of(false));
+
+    const guard = orgAdminGuard();
+    let completionCalled = false;
+    guard.subscribe({
+      complete: () => {
+        completionCalled = true;
+        expect(completionCalled).toBe(true);
+        done();
+      },
+    });
+  });
+
+  it('should navigate to dashboard when access denied', (done) => {
+    store.select.and.returnValues(of(false), of(false));
+
+    const guard = orgAdminGuard();
+    guard.subscribe(() => {
+      setTimeout(() => {
+        expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+        done();
+      }, 0);
+    });
+  });
+
+  it('should handle store selection errors gracefully', (done) => {
+    store.select.and.returnValue(throwError(() => new Error('Store error')));
+
+    const guard = orgAdminGuard();
+    guard.subscribe(
+      () => fail('should have errored'),
+      (error) => {
+        expect(error).toBeTruthy();
+        done();
+      }
+    );
+  });
+
+  it('should use combineLatest to wait for both selectors', (done) => {
+    store.select.and.returnValues(of(true), of(true));
+
+    const guard = orgAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(true);
+      done();
+    });
+  });
+
+  describe('Access control matrix', () => {
+    const testCases = [
+      {
+        isSuperAdmin: true,
+        isOrgAdmin: true,
+        shouldAllow: true,
+        description: 'Both SUPER_ADMIN and ORG_ADMIN',
+      },
+      { isSuperAdmin: true, isOrgAdmin: false, shouldAllow: true, description: 'Only SUPER_ADMIN' },
+      { isSuperAdmin: false, isOrgAdmin: true, shouldAllow: true, description: 'Only ORG_ADMIN' },
+      {
+        isSuperAdmin: false,
+        isOrgAdmin: false,
+        shouldAllow: false,
+        description: 'Neither SUPER_ADMIN nor ORG_ADMIN',
+      },
+    ];
+
+    testCases.forEach(({ isSuperAdmin, isOrgAdmin, shouldAllow, description }) => {
+      it(`should ${shouldAllow ? 'allow' : 'deny'} access for: ${description}`, (done) => {
+        store.select.and.returnValues(of(isSuperAdmin), of(isOrgAdmin));
+
+        const guard = orgAdminGuard();
+        guard.subscribe((result) => {
+          expect(result).toBe(shouldAllow);
+
+          if (!shouldAllow) {
+            expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+          } else {
+            expect(router.navigate).not.toHaveBeenCalled();
+          }
+
+          done();
+        });
+      });
+    });
+  });
+
+  it('should return observable that completes', (done) => {
+    store.select.and.returnValues(of(true), of(false));
+    let completed = false;
+
+    const guard = orgAdminGuard();
+    guard.subscribe({
+      complete: () => {
+        completed = true;
+        expect(completed).toBe(true);
+        done();
+      },
+    });
+  });
+});

--- a/src/frontend/src/app/core/guards/org-admin.guard.ts
+++ b/src/frontend/src/app/core/guards/org-admin.guard.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { map, take } from 'rxjs/operators';
+import { selectIsSuperAdmin, selectIsOrgAdmin } from '../../store/auth/auth.selectors';
+import { combineLatest } from 'rxjs';
+
+export const orgAdminGuard = () => {
+  const store = inject(Store);
+  const router = inject(Router);
+
+  return combineLatest([store.select(selectIsSuperAdmin), store.select(selectIsOrgAdmin)]).pipe(
+    take(1),
+    map(([isSuperAdmin, isOrgAdmin]) => {
+      if (isSuperAdmin || isOrgAdmin) {
+        return true;
+      }
+      router.navigate(['/dashboard']);
+      return false;
+    })
+  );
+};

--- a/src/frontend/src/app/core/guards/super-admin.guard.spec.ts
+++ b/src/frontend/src/app/core/guards/super-admin.guard.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { of, throwError } from 'rxjs';
+import { superAdminGuard } from './super-admin.guard';
+
+describe('superAdminGuard', () => {
+  let store: jasmine.SpyObj<Store>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    const storeSpy = jasmine.createSpyObj('Store', ['select']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Store, useValue: storeSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    store = TestBed.inject(Store) as jasmine.SpyObj<Store>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+  });
+
+  it('should allow access for SUPER_ADMIN user', (done) => {
+    store.select.and.returnValue(of(true));
+
+    const guard = superAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(true);
+      expect(router.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should deny access and navigate for non-SUPER_ADMIN user', (done) => {
+    store.select.and.returnValue(of(false));
+
+    const guard = superAdminGuard();
+    guard.subscribe((result) => {
+      expect(result).toBe(false);
+      expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+      done();
+    });
+  });
+
+  it('should select isSuperAdmin from store', (done) => {
+    store.select.and.returnValue(of(true));
+
+    const guard = superAdminGuard();
+    guard.subscribe(() => {
+      expect(store.select).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should use take(1) operator to complete immediately', (done) => {
+    let emissionCount = 0;
+    const testObservable = of(true);
+    store.select.and.returnValue(testObservable);
+
+    const guard = superAdminGuard();
+    guard.subscribe({
+      next: () => {
+        emissionCount++;
+      },
+      complete: () => {
+        expect(emissionCount).toBe(1);
+        done();
+      },
+    });
+  });
+
+  it('should navigate to dashboard when access denied', (done) => {
+    store.select.and.returnValue(of(false));
+
+    const guard = superAdminGuard();
+    guard.subscribe(() => {
+      setTimeout(() => {
+        expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+        done();
+      }, 0);
+    });
+  });
+
+  it('should handle store selection errors gracefully', (done) => {
+    store.select.and.returnValue(throwError(() => new Error('Store error')));
+
+    const guard = superAdminGuard();
+    guard.subscribe(
+      () => fail('should have errored'),
+      (error) => {
+        expect(error).toBeTruthy();
+        done();
+      }
+    );
+  });
+
+  it('should return observable that completes', (done) => {
+    store.select.and.returnValue(of(true));
+    let completed = false;
+
+    const guard = superAdminGuard();
+    guard.subscribe({
+      complete: () => {
+        completed = true;
+        expect(completed).toBe(true);
+        done();
+      },
+    });
+  });
+});

--- a/src/frontend/src/app/core/guards/super-admin.guard.ts
+++ b/src/frontend/src/app/core/guards/super-admin.guard.ts
@@ -1,0 +1,21 @@
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { map, take } from 'rxjs/operators';
+import { selectIsSuperAdmin } from '../../store/auth/auth.selectors';
+
+export const superAdminGuard = () => {
+  const store = inject(Store);
+  const router = inject(Router);
+
+  return store.select(selectIsSuperAdmin).pipe(
+    take(1),
+    map((isSuperAdmin) => {
+      if (isSuperAdmin) {
+        return true;
+      }
+      router.navigate(['/dashboard']);
+      return false;
+    })
+  );
+};

--- a/src/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -6,7 +6,6 @@ import { catchError, switchMap, throwError, take, filter } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { AppState } from '../../store';
 import * as AuthSelectors from '../../store/auth/auth.selectors';
-import * as AuthActions from '../../store/auth/auth.actions';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);

--- a/src/frontend/src/app/core/models/audit-log.model.ts
+++ b/src/frontend/src/app/core/models/audit-log.model.ts
@@ -1,0 +1,22 @@
+export interface AuditLog {
+  id: number;
+  organizationId: number;
+  userId: number;
+  userEmail: string;
+  action: string;
+  resourceType: string;
+  resourceId?: number;
+  resourceName?: string;
+  ipAddress: string;
+  status: 'success' | 'failure';
+  changes?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface AuditFilter {
+  action?: string;
+  resourceType?: string;
+  userId?: number;
+  startDate?: Date;
+  endDate?: Date;
+}

--- a/src/frontend/src/app/core/models/building.model.ts
+++ b/src/frontend/src/app/core/models/building.model.ts
@@ -13,7 +13,7 @@ export interface BuildingMetadata {
   maintenance_staff_count?: number;
 
   // Other attributes
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface Building {

--- a/src/frontend/src/app/core/models/index.ts
+++ b/src/frontend/src/app/core/models/index.ts
@@ -6,3 +6,7 @@ export * from './tenant.model';
 export * from './lease.model';
 export * from './payment.model';
 export * from './api-response.model';
+export * from './role.model';
+export * from './organization.model';
+export * from './user-invitation.model';
+export * from './audit-log.model';

--- a/src/frontend/src/app/core/models/organization.model.ts
+++ b/src/frontend/src/app/core/models/organization.model.ts
@@ -1,0 +1,31 @@
+export interface Organization {
+  id: number;
+  name: string;
+  slug: string;
+  subscriptionTier: 'basic' | 'professional' | 'enterprise';
+  maxUsers: number;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateOrgRequest {
+  name: string;
+  slug: string;
+  subscriptionTier: 'basic' | 'professional' | 'enterprise';
+  maxUsers: number;
+}
+
+export interface UpdateOrgRequest {
+  name?: string;
+  subscriptionTier?: 'basic' | 'professional' | 'enterprise';
+  maxUsers?: number;
+  active?: boolean;
+}
+
+export interface OrgStats {
+  totalUsers: number;
+  usersByRole: Record<string, number>;
+  pendingInvitations: number;
+  activeProperties: number;
+}

--- a/src/frontend/src/app/core/models/property.model.ts
+++ b/src/frontend/src/app/core/models/property.model.ts
@@ -1,6 +1,6 @@
 export type PropertyType = 'Residential' | 'Commercial' | 'Mixed';
 
-export type PropertyMetadata = Record<string, any>;
+export type PropertyMetadata = Record<string, unknown>;
 
 export interface Property {
   id: number;

--- a/src/frontend/src/app/core/models/role.model.ts
+++ b/src/frontend/src/app/core/models/role.model.ts
@@ -1,11 +1,25 @@
 // Role types
-export type UserRole = 'Admin' | 'PropertyManager' | 'Accountant' | string; // string allows future roles
+export type UserRole = 'SUPER_ADMIN' | 'ORG_ADMIN' | 'Admin' | 'PropertyManager' | 'Accountant';
+
+// Role hierarchy (lower number = higher privilege)
+export const ROLE_HIERARCHY: Record<UserRole, number> = {
+  SUPER_ADMIN: 0,
+  ORG_ADMIN: 1,
+  Admin: 2,
+  PropertyManager: 3,
+  Accountant: 4,
+};
 
 // Permission types
 export enum Permission {
+  // Organization Management
+  MANAGE_ORGANIZATIONS = 'manage_organizations',
+  MANAGE_ORG_ADMINS = 'manage_org_admins',
+
   // User Management
   MANAGE_USERS = 'manage_users',
   VIEW_USERS = 'view_users',
+  INVITE_USERS = 'invite_users',
 
   // Property Management
   MANAGE_PROPERTIES = 'manage_properties',
@@ -36,9 +50,68 @@ export enum Permission {
 
 // Role-Permission mapping
 export const ROLE_PERMISSIONS: Record<string, Permission[]> = {
+  SUPER_ADMIN: [
+    // Organization
+    Permission.MANAGE_ORGANIZATIONS,
+    Permission.MANAGE_ORG_ADMINS,
+    // Users
+    Permission.MANAGE_USERS,
+    Permission.VIEW_USERS,
+    Permission.INVITE_USERS,
+    // Properties
+    Permission.MANAGE_PROPERTIES,
+    Permission.VIEW_PROPERTIES,
+    Permission.MANAGE_BUILDINGS,
+    Permission.MANAGE_UNITS,
+    // Tenants
+    Permission.MANAGE_TENANTS,
+    Permission.VIEW_TENANTS,
+    Permission.MANAGE_LEASES,
+    Permission.VIEW_LEASES,
+    // Financial
+    Permission.RECORD_PAYMENTS,
+    Permission.VIEW_PAYMENTS,
+    Permission.VIEW_REPORTS,
+    Permission.EXPORT_REPORTS,
+    // Documents
+    Permission.MANAGE_DOCUMENTS,
+    Permission.VIEW_DOCUMENTS,
+    // System
+    Permission.VIEW_DASHBOARD,
+    Permission.MANAGE_SETTINGS,
+  ],
+  ORG_ADMIN: [
+    // Users (no organization management)
+    Permission.MANAGE_USERS,
+    Permission.VIEW_USERS,
+    Permission.INVITE_USERS,
+    Permission.MANAGE_ORG_ADMINS,
+    // Properties
+    Permission.MANAGE_PROPERTIES,
+    Permission.VIEW_PROPERTIES,
+    Permission.MANAGE_BUILDINGS,
+    Permission.MANAGE_UNITS,
+    // Tenants
+    Permission.MANAGE_TENANTS,
+    Permission.VIEW_TENANTS,
+    Permission.MANAGE_LEASES,
+    Permission.VIEW_LEASES,
+    // Financial
+    Permission.RECORD_PAYMENTS,
+    Permission.VIEW_PAYMENTS,
+    Permission.VIEW_REPORTS,
+    Permission.EXPORT_REPORTS,
+    // Documents
+    Permission.MANAGE_DOCUMENTS,
+    Permission.VIEW_DOCUMENTS,
+    // System
+    Permission.VIEW_DASHBOARD,
+    Permission.MANAGE_SETTINGS,
+  ],
   Admin: [
     Permission.MANAGE_USERS,
     Permission.VIEW_USERS,
+    Permission.INVITE_USERS,
     Permission.MANAGE_PROPERTIES,
     Permission.VIEW_PROPERTIES,
     Permission.MANAGE_BUILDINGS,
@@ -57,6 +130,7 @@ export const ROLE_PERMISSIONS: Record<string, Permission[]> = {
     Permission.MANAGE_SETTINGS,
   ],
   PropertyManager: [
+    Permission.VIEW_USERS,
     Permission.VIEW_PROPERTIES,
     Permission.MANAGE_PROPERTIES,
     Permission.MANAGE_BUILDINGS,
@@ -73,6 +147,7 @@ export const ROLE_PERMISSIONS: Record<string, Permission[]> = {
     Permission.VIEW_DASHBOARD,
   ],
   Accountant: [
+    Permission.VIEW_USERS,
     Permission.VIEW_PROPERTIES,
     Permission.VIEW_TENANTS,
     Permission.VIEW_LEASES,

--- a/src/frontend/src/app/core/models/unit.model.ts
+++ b/src/frontend/src/app/core/models/unit.model.ts
@@ -45,7 +45,7 @@ export type UnitMetadata =
   | OfficeMetadata
   | ParkingMetadata
   | StorageMetadata
-  | Record<string, any>;
+  | Record<string, unknown>;
 
 export interface Unit {
   id: number;

--- a/src/frontend/src/app/core/models/user-invitation.model.ts
+++ b/src/frontend/src/app/core/models/user-invitation.model.ts
@@ -1,0 +1,19 @@
+import { UserRole } from './role.model';
+
+export interface UserInvitation {
+  id: number;
+  organizationId: number;
+  email: string;
+  role: UserRole;
+  token: string;
+  expiresAt: Date;
+  acceptedAt?: Date;
+  createdAt: Date;
+}
+
+export interface InviteUserRequest {
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: UserRole;
+}

--- a/src/frontend/src/app/core/services/attachment.service.ts
+++ b/src/frontend/src/app/core/services/attachment.service.ts
@@ -218,7 +218,7 @@ export class AttachmentService {
     return this.http.post<Attachment>(this.apiUrl, formData);
   }
 
-  updateAttachment(id: number, request: UpdateAttachmentRequest): Observable<any> {
+  updateAttachment(id: number, request: UpdateAttachmentRequest): Observable<{ message: string }> {
     if (this.DEMO_MODE) {
       return new Observable((observer) => {
         const attachmentIndex = this.demoAttachments.findIndex((a) => a.id === id);
@@ -236,10 +236,10 @@ export class AttachmentService {
       });
     }
 
-    return this.http.put(`${this.apiUrl}/${id}`, request);
+    return this.http.put<{ message: string }>(`${this.apiUrl}/${id}`, request);
   }
 
-  deleteAttachment(id: number): Observable<any> {
+  deleteAttachment(id: number): Observable<{ message: string }> {
     if (this.DEMO_MODE) {
       return new Observable((observer) => {
         const attachmentIndex = this.demoAttachments.findIndex((a) => a.id === id);
@@ -253,7 +253,7 @@ export class AttachmentService {
       });
     }
 
-    return this.http.delete(`${this.apiUrl}/${id}`);
+    return this.http.delete<{ message: string }>(`${this.apiUrl}/${id}`);
   }
 
   downloadAttachment(id: number): Observable<Blob> {

--- a/src/frontend/src/app/core/services/audit-log.service.ts
+++ b/src/frontend/src/app/core/services/audit-log.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuditLog, AuditFilter } from '../models';
+import { environment } from '../../../environments/environment';
+
+interface AuditLogListResponse {
+  logs: AuditLog[];
+  total: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuditLogService {
+  private http = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/organizations`;
+
+  getAuditLogs(
+    orgId: number,
+    filters?: AuditFilter & { page?: number; limit?: number }
+  ): Observable<AuditLogListResponse> {
+    let httpParams = new HttpParams();
+
+    if (filters?.page) {
+      httpParams = httpParams.set('page', filters.page.toString());
+    }
+    if (filters?.limit) {
+      httpParams = httpParams.set('limit', filters.limit.toString());
+    }
+    if (filters?.action) {
+      httpParams = httpParams.set('action', filters.action);
+    }
+    if (filters?.resourceType) {
+      httpParams = httpParams.set('resourceType', filters.resourceType);
+    }
+    if (filters?.userId) {
+      httpParams = httpParams.set('userId', filters.userId.toString());
+    }
+    if (filters?.startDate) {
+      httpParams = httpParams.set('startDate', filters.startDate.toISOString());
+    }
+    if (filters?.endDate) {
+      httpParams = httpParams.set('endDate', filters.endDate.toISOString());
+    }
+
+    return this.http.get<AuditLogListResponse>(`${this.apiUrl}/${orgId}/audit-logs`, {
+      params: httpParams,
+    });
+  }
+
+  exportAuditLogs(orgId: number, filters?: AuditFilter): Observable<Blob> {
+    let httpParams = new HttpParams();
+
+    if (filters?.action) {
+      httpParams = httpParams.set('action', filters.action);
+    }
+    if (filters?.resourceType) {
+      httpParams = httpParams.set('resourceType', filters.resourceType);
+    }
+    if (filters?.userId) {
+      httpParams = httpParams.set('userId', filters.userId.toString());
+    }
+    if (filters?.startDate) {
+      httpParams = httpParams.set('startDate', filters.startDate.toISOString());
+    }
+    if (filters?.endDate) {
+      httpParams = httpParams.set('endDate', filters.endDate.toISOString());
+    }
+
+    return this.http.get<Blob>(`${this.apiUrl}/${orgId}/audit-logs/export`, {
+      params: httpParams,
+      responseType: 'blob' as 'json',
+    });
+  }
+}

--- a/src/frontend/src/app/core/services/auth.service.spec.ts
+++ b/src/frontend/src/app/core/services/auth.service.spec.ts
@@ -59,13 +59,18 @@ describe('AuthService', () => {
     service = TestBed.inject(AuthService);
     store = TestBed.inject(Store) as jasmine.SpyObj<Store<AppState>>;
 
-    // Clear localStorage before each test
-    localStorage.clear();
-  });
-
-  afterEach(() => {
-    // Clean up localStorage after each test
-    localStorage.clear();
+    // Setup default store selectors
+    store.select.and.callFake((selector: unknown) => {
+      if (selector === AuthSelectors.selectUser) return of(mockUser);
+      if (selector === AuthSelectors.selectUserRole) return of('Admin');
+      if (selector === AuthSelectors.selectIsAuthenticated) return of(true);
+      if (selector === AuthSelectors.selectIsAdmin) return of(true);
+      if (selector === AuthSelectors.selectIsPropertyManager) return of(false);
+      if (selector === AuthSelectors.selectIsAccountant) return of(false);
+      if (selector === AuthSelectors.selectAuthLoading) return of(false);
+      if (selector === AuthSelectors.selectAuthError) return of(null);
+      return of(null);
+    });
   });
 
   it('should be created', () => {
@@ -347,7 +352,10 @@ describe('AuthService', () => {
     });
 
     it('should return false when user does not have the specified role', () => {
-      store.select.and.returnValue(of('PropertyManager'));
+      store.select.and.callFake((selector: unknown) => {
+        if (selector === AuthSelectors.selectUserRole) return of('PropertyManager');
+        return of(null);
+      });
 
       const result = service.hasRole('Admin');
 
@@ -379,7 +387,10 @@ describe('AuthService', () => {
     });
 
     it('should return false when user does not have any of the specified roles', () => {
-      store.select.and.returnValue(of('Accountant'));
+      store.select.and.callFake((selector: unknown) => {
+        if (selector === AuthSelectors.selectUserRole) return of('Accountant');
+        return of(null);
+      });
 
       const result = service.hasAnyRole(['Admin', 'PropertyManager']);
 

--- a/src/frontend/src/app/core/services/auth.service.ts
+++ b/src/frontend/src/app/core/services/auth.service.ts
@@ -1,9 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { tap, map, take } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
-import { environment } from '../../../environments/environment';
 import { AppState } from '../../store';
 import * as AuthSelectors from '../../store/auth/auth.selectors';
 import * as AuthActions from '../../store/auth/auth.actions';
@@ -18,6 +17,9 @@ export interface User {
   username: string;
   email: string;
   role: string;
+  organization_id?: number;
+  first_name?: string;
+  last_name?: string;
   active: boolean;
   created_at: string;
   updated_at: string;

--- a/src/frontend/src/app/core/services/building.service.ts
+++ b/src/frontend/src/app/core/services/building.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import {
   Building,
   BuildingWithStats,

--- a/src/frontend/src/app/core/services/lease.service.ts
+++ b/src/frontend/src/app/core/services/lease.service.ts
@@ -158,7 +158,7 @@ export class LeaseService {
     return this.http.post<Lease>(this.apiUrl, request);
   }
 
-  updateLease(id: number, request: UpdateLeaseRequest): Observable<any> {
+  updateLease(id: number, request: UpdateLeaseRequest): Observable<{ message: string }> {
     if (this.DEMO_MODE) {
       return new Observable((observer) => {
         observer.next({ message: 'Lease updated successfully' });
@@ -166,10 +166,10 @@ export class LeaseService {
       });
     }
 
-    return this.http.put(`${this.apiUrl}/${id}`, request);
+    return this.http.put<{ message: string }>(`${this.apiUrl}/${id}`, request);
   }
 
-  deleteLease(id: number): Observable<any> {
+  deleteLease(id: number): Observable<{ message: string }> {
     if (this.DEMO_MODE) {
       return new Observable((observer) => {
         observer.next({ message: 'Lease deleted successfully' });
@@ -177,7 +177,7 @@ export class LeaseService {
       });
     }
 
-    return this.http.delete(`${this.apiUrl}/${id}`);
+    return this.http.delete<{ message: string }>(`${this.apiUrl}/${id}`);
   }
 
   getActiveLeases(): Observable<LeaseWithDetails[]> {

--- a/src/frontend/src/app/core/services/organization.service.spec.ts
+++ b/src/frontend/src/app/core/services/organization.service.spec.ts
@@ -1,0 +1,456 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { OrganizationService } from './organization.service';
+import { Organization, CreateOrgRequest, UpdateOrgRequest, OrgStats } from '../models';
+
+describe('OrganizationService', () => {
+  let service: OrganizationService;
+  let httpMock: HttpTestingController;
+  const apiUrl = '/api/v1/organizations';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [OrganizationService],
+    });
+    service = TestBed.inject(OrganizationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('Initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should initialize currentOrganization$ as null', () => {
+      expect(service.currentOrganization$.value).toBeNull();
+    });
+  });
+
+  describe('getOrganizations', () => {
+    it('should fetch all organizations', () => {
+      const mockOrgs: Organization[] = [
+        {
+          id: 1,
+          name: 'Org 1',
+          slug: 'org-1',
+          subscriptionTier: 'basic',
+          maxUsers: 10,
+          active: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 2,
+          name: 'Org 2',
+          slug: 'org-2',
+          subscriptionTier: 'professional',
+          maxUsers: 50,
+          active: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      service.getOrganizations().subscribe((result) => {
+        expect(result.organizations).toEqual(mockOrgs);
+        expect(result.total).toBe(2);
+      });
+
+      const req = httpMock.expectOne(apiUrl);
+      expect(req.request.method).toBe('GET');
+      req.flush({ organizations: mockOrgs, total: 2 });
+    });
+
+    it('should handle empty organizations list', () => {
+      service.getOrganizations().subscribe((result) => {
+        expect(result.organizations).toEqual([]);
+        expect(result.total).toBe(0);
+      });
+
+      const req = httpMock.expectOne(apiUrl);
+      req.flush({ organizations: [], total: 0 });
+    });
+
+    it('should handle error response', () => {
+      service.getOrganizations().subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(500);
+        }
+      );
+
+      const req = httpMock.expectOne(apiUrl);
+      req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+    });
+  });
+
+  describe('getOrganization', () => {
+    it('should fetch a single organization by id', () => {
+      const mockOrg: Organization = {
+        id: 1,
+        name: 'Test Org',
+        slug: 'test-org',
+        subscriptionTier: 'professional',
+        maxUsers: 50,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      service.getOrganization(1).subscribe((result) => {
+        expect(result).toEqual(mockOrg);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockOrg);
+    });
+
+    it('should handle 404 not found error', () => {
+      service.getOrganization(999).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(404);
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/999`);
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  describe('createOrganization', () => {
+    it('should create a new organization', () => {
+      const createReq: CreateOrgRequest = {
+        name: 'New Org',
+        slug: 'new-org',
+        subscriptionTier: 'professional',
+        maxUsers: 50,
+      };
+
+      const mockOrg: Organization = {
+        id: 1,
+        ...createReq,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      service.createOrganization(createReq).subscribe((result) => {
+        expect(result.id).toBe(1);
+        expect(result.name).toBe('New Org');
+        expect(result.slug).toBe('new-org');
+        expect(result.subscriptionTier).toBe('professional');
+        expect(result.active).toBe(true);
+      });
+
+      const req = httpMock.expectOne(apiUrl);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(createReq);
+      req.flush(mockOrg);
+    });
+
+    it('should handle validation error on create', () => {
+      const invalidReq: CreateOrgRequest = {
+        name: '',
+        slug: '',
+        subscriptionTier: 'basic',
+        maxUsers: 0,
+      };
+
+      service.createOrganization(invalidReq).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(400);
+        }
+      );
+
+      const req = httpMock.expectOne(apiUrl);
+      req.flush('Validation failed', { status: 400, statusText: 'Bad Request' });
+    });
+
+    it('should send correct POST body structure', () => {
+      const createReq: CreateOrgRequest = {
+        name: 'Test',
+        slug: 'test',
+        subscriptionTier: 'enterprise',
+        maxUsers: 1000,
+      };
+
+      service.createOrganization(createReq).subscribe();
+
+      const req = httpMock.expectOne(apiUrl);
+      expect(req.request.body).toEqual({
+        name: 'Test',
+        slug: 'test',
+        subscriptionTier: 'enterprise',
+        maxUsers: 1000,
+      });
+      req.flush({} as Organization);
+    });
+  });
+
+  describe('updateOrganization', () => {
+    it('should update an organization', () => {
+      const updateReq: UpdateOrgRequest = {
+        name: 'Updated Org',
+        maxUsers: 100,
+      };
+
+      const mockOrg: Organization = {
+        id: 1,
+        name: 'Updated Org',
+        slug: 'new-org',
+        subscriptionTier: 'professional',
+        maxUsers: 100,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      service.updateOrganization(1, updateReq).subscribe((result) => {
+        expect(result.name).toBe('Updated Org');
+        expect(result.maxUsers).toBe(100);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/1`);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(updateReq);
+      req.flush(mockOrg);
+    });
+
+    it('should support partial updates', () => {
+      const updateReq: UpdateOrgRequest = {
+        maxUsers: 200,
+      };
+
+      service.updateOrganization(1, updateReq).subscribe();
+
+      const req = httpMock.expectOne(`${apiUrl}/1`);
+      expect(req.request.body).toEqual({ maxUsers: 200 });
+      req.flush({} as Organization);
+    });
+
+    it('should handle update conflict', () => {
+      const updateReq: UpdateOrgRequest = { name: 'Updated' };
+
+      service.updateOrganization(1, updateReq).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(409);
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/1`);
+      req.flush('Conflict', { status: 409, statusText: 'Conflict' });
+    });
+  });
+
+  describe('deleteOrganization', () => {
+    it('should delete an organization', () => {
+      service.deleteOrganization(1).subscribe();
+
+      const req = httpMock.expectOne(`${apiUrl}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+
+    it('should handle delete of non-existent org', () => {
+      service.deleteOrganization(999).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(404);
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/999`);
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  describe('getOrganizationUsers', () => {
+    it('should fetch organization users', () => {
+      const mockUsers = [
+        {
+          id: 1,
+          username: 'user1',
+          email: 'user1@test.com',
+          role: 'Admin',
+          active: true,
+          created_at: '',
+          updated_at: '',
+        },
+        {
+          id: 2,
+          username: 'user2',
+          email: 'user2@test.com',
+          role: 'PropertyManager',
+          active: true,
+          created_at: '',
+          updated_at: '',
+        },
+      ];
+
+      service.getOrganizationUsers(1).subscribe((result) => {
+        expect(result.users.length).toBe(2);
+        expect(result.total).toBe(2);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/1/users`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ users: mockUsers, total: 2 });
+    });
+
+    it('should support pagination parameters', () => {
+      service.getOrganizationUsers(1, { page: 2, limit: 25 }).subscribe();
+
+      const req = httpMock.expectOne((r) => r.url.includes(`${apiUrl}/1/users`));
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('limit')).toBe('25');
+      req.flush({ users: [], total: 0 });
+    });
+
+    it('should handle empty users list', () => {
+      service.getOrganizationUsers(1).subscribe((result) => {
+        expect(result.users).toEqual([]);
+        expect(result.total).toBe(0);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/1/users`);
+      req.flush({ users: [], total: 0 });
+    });
+  });
+
+  describe('getOrganizationStats', () => {
+    it('should fetch organization statistics', () => {
+      const mockStats: OrgStats = {
+        totalUsers: 50,
+        usersByRole: {
+          SUPER_ADMIN: 1,
+          ORG_ADMIN: 2,
+          Admin: 5,
+          PropertyManager: 20,
+          Accountant: 22,
+        },
+        pendingInvitations: 3,
+        activeProperties: 10,
+      };
+
+      service.getOrganizationStats(1).subscribe((result) => {
+        expect(result.totalUsers).toBe(50);
+        expect(result.pendingInvitations).toBe(3);
+        expect(result.activeProperties).toBe(10);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/1/stats`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockStats);
+    });
+  });
+
+  describe('getCurrentOrganization', () => {
+    it('should return null when no organization is set', () => {
+      expect(service.getCurrentOrganization()).toBeNull();
+    });
+
+    it('should return current organization when set', () => {
+      const mockOrg: Organization = {
+        id: 1,
+        name: 'Test Org',
+        slug: 'test-org',
+        subscriptionTier: 'basic',
+        maxUsers: 10,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      service.setCurrentOrganization(mockOrg);
+      expect(service.getCurrentOrganization()).toEqual(mockOrg);
+    });
+  });
+
+  describe('setCurrentOrganization', () => {
+    it('should update currentOrganization$ BehaviorSubject', (done) => {
+      const mockOrg: Organization = {
+        id: 1,
+        name: 'Test Org',
+        slug: 'test-org',
+        subscriptionTier: 'basic',
+        maxUsers: 10,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      let emissionCount = 0;
+      service.currentOrganization$.subscribe((org) => {
+        emissionCount++;
+        if (emissionCount === 2) {
+          // First emission is null, second is the org
+          expect(org?.id).toBe(1);
+          expect(org?.name).toBe('Test Org');
+          done();
+        }
+      });
+
+      service.setCurrentOrganization(mockOrg);
+    });
+
+    it('should allow clearing current organization', (done) => {
+      const mockOrg: Organization = {
+        id: 1,
+        name: 'Test Org',
+        slug: 'test-org',
+        subscriptionTier: 'basic',
+        maxUsers: 10,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      service.setCurrentOrganization(mockOrg);
+      service.setCurrentOrganization(null);
+
+      service.currentOrganization$.subscribe((org) => {
+        expect(org).toBeNull();
+        done();
+      });
+    });
+  });
+
+  describe('Multiple concurrent requests', () => {
+    it('should handle multiple concurrent requests', () => {
+      const mockOrg: Organization = {
+        id: 1,
+        name: 'Test',
+        slug: 'test',
+        subscriptionTier: 'basic',
+        maxUsers: 10,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      let completedRequests = 0;
+
+      service.getOrganizations().subscribe(() => completedRequests++);
+      service.getOrganization(1).subscribe(() => completedRequests++);
+      service.getOrganizationUsers(1).subscribe(() => completedRequests++);
+
+      const requests = httpMock.match(() => true);
+      expect(requests.length).toBe(3);
+
+      requests[0].flush({ organizations: [mockOrg], total: 1 });
+      requests[1].flush(mockOrg);
+      requests[2].flush({ users: [], total: 0 });
+
+      expect(completedRequests).toBe(3);
+    });
+  });
+});

--- a/src/frontend/src/app/core/services/organization.service.ts
+++ b/src/frontend/src/app/core/services/organization.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Organization, CreateOrgRequest, UpdateOrgRequest, OrgStats } from '../models';
+import { environment } from '../../../environments/environment';
+import { User } from './auth.service';
+
+interface OrgListResponse {
+  organizations: Organization[];
+  total: number;
+}
+
+interface OrgUsersResponse {
+  users: User[];
+  total: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrganizationService {
+  private http = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/organizations`;
+
+  // Current organization context
+  public currentOrganization$ = new BehaviorSubject<Organization | null>(null);
+
+  getOrganizations(): Observable<OrgListResponse> {
+    return this.http.get<OrgListResponse>(this.apiUrl);
+  }
+
+  getOrganization(id: number): Observable<Organization> {
+    return this.http.get<Organization>(`${this.apiUrl}/${id}`);
+  }
+
+  createOrganization(req: CreateOrgRequest): Observable<Organization> {
+    return this.http.post<Organization>(this.apiUrl, req);
+  }
+
+  updateOrganization(id: number, req: UpdateOrgRequest): Observable<Organization> {
+    return this.http.put<Organization>(`${this.apiUrl}/${id}`, req);
+  }
+
+  deleteOrganization(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+
+  getOrganizationUsers(
+    orgId: number,
+    params?: { page?: number; limit?: number }
+  ): Observable<OrgUsersResponse> {
+    let httpParams = new HttpParams();
+    if (params?.page) {
+      httpParams = httpParams.set('page', params.page.toString());
+    }
+    if (params?.limit) {
+      httpParams = httpParams.set('limit', params.limit.toString());
+    }
+    return this.http.get<OrgUsersResponse>(`${this.apiUrl}/${orgId}/users`, {
+      params: httpParams,
+    });
+  }
+
+  getOrganizationStats(orgId: number): Observable<OrgStats> {
+    return this.http.get<OrgStats>(`${this.apiUrl}/${orgId}/stats`);
+  }
+
+  getCurrentOrganization(): Organization | null {
+    return this.currentOrganization$.value;
+  }
+
+  setCurrentOrganization(org: Organization | null): void {
+    this.currentOrganization$.next(org);
+  }
+}

--- a/src/frontend/src/app/core/services/permission.service.spec.ts
+++ b/src/frontend/src/app/core/services/permission.service.spec.ts
@@ -1,0 +1,448 @@
+import { TestBed } from '@angular/core/testing';
+import { PermissionService } from './permission.service';
+import { AuthService } from './auth.service';
+import { Permission, ROLE_HIERARCHY, ROLE_PERMISSIONS } from '../models/role.model';
+import { of, Observable } from 'rxjs';
+
+describe('PermissionService', () => {
+  let service: PermissionService;
+  let authServiceMock: { userRole$: Observable<string | null> };
+
+  beforeEach(() => {
+    authServiceMock = {
+      userRole$: of('Admin'),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [PermissionService, { provide: AuthService, useValue: authServiceMock }],
+    });
+    service = TestBed.inject(PermissionService);
+  });
+
+  describe('Initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should initialize userRole signal from AuthService', (done) => {
+      authServiceMock.userRole$ = of('PropertyManager');
+      const newService = TestBed.inject(PermissionService);
+
+      // Use a small timeout to allow the signal to update
+      setTimeout(() => {
+        expect(newService.getCurrentRole()).toBe('PropertyManager');
+        done();
+      }, 100);
+    });
+  });
+
+  describe('Role checks - isSuperAdmin', () => {
+    it('should return true for SUPER_ADMIN role', () => {
+      authServiceMock.userRole$ = of('SUPER_ADMIN');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isSuperAdmin()).toBe(true);
+    });
+
+    it('should return false for non-SUPER_ADMIN roles', () => {
+      const roles = ['ORG_ADMIN', 'Admin', 'PropertyManager', 'Accountant'];
+
+      roles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.isSuperAdmin()).toBe(false);
+      });
+    });
+  });
+
+  describe('Role checks - isOrgAdmin', () => {
+    it('should return true for ORG_ADMIN role', () => {
+      authServiceMock.userRole$ = of('ORG_ADMIN');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isOrgAdmin()).toBe(true);
+    });
+
+    it('should return false for non-ORG_ADMIN roles', () => {
+      const roles = ['SUPER_ADMIN', 'Admin', 'PropertyManager', 'Accountant'];
+
+      roles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.isOrgAdmin()).toBe(false);
+      });
+    });
+  });
+
+  describe('Role checks - isAdmin', () => {
+    it('should return true for Admin role', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isAdmin()).toBe(true);
+    });
+
+    it('should return false for non-Admin roles', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'PropertyManager', 'Accountant'];
+
+      roles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.isAdmin()).toBe(false);
+      });
+    });
+  });
+
+  describe('Role checks - isPropertyManager', () => {
+    it('should return true for PropertyManager role', () => {
+      authServiceMock.userRole$ = of('PropertyManager');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isPropertyManager()).toBe(true);
+    });
+
+    it('should return false for non-PropertyManager roles', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'Accountant'];
+
+      roles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.isPropertyManager()).toBe(false);
+      });
+    });
+  });
+
+  describe('Role checks - isAccountant', () => {
+    it('should return true for Accountant role', () => {
+      authServiceMock.userRole$ = of('Accountant');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isAccountant()).toBe(true);
+    });
+
+    it('should return false for non-Accountant roles', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'PropertyManager'];
+
+      roles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.isAccountant()).toBe(false);
+      });
+    });
+  });
+
+  describe('Permission checks - hasPermission', () => {
+    it('should return true for Admin with manage_users permission', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.hasPermission(Permission.MANAGE_USERS)).toBe(true);
+    });
+
+    it('should return false for Accountant with manage_users permission', () => {
+      authServiceMock.userRole$ = of('Accountant');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.hasPermission(Permission.MANAGE_USERS)).toBe(false);
+    });
+
+    it('should return true for Accountant with view_payments permission', () => {
+      authServiceMock.userRole$ = of('Accountant');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.hasPermission(Permission.VIEW_PAYMENTS)).toBe(true);
+    });
+  });
+
+  describe('Permission checks - hasAnyPermission', () => {
+    it('should return true if user has any of the specified permissions', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      const permissions = [Permission.VIEW_DASHBOARD, Permission.MANAGE_USERS];
+      expect(newService.hasAnyPermission(permissions)).toBe(true);
+    });
+
+    it('should return false if user has none of the specified permissions', () => {
+      authServiceMock.userRole$ = of('Accountant');
+      const newService = TestBed.inject(PermissionService);
+      const permissions = [Permission.MANAGE_USERS, Permission.MANAGE_PROPERTIES];
+      expect(newService.hasAnyPermission(permissions)).toBe(false);
+    });
+  });
+
+  describe('Permission checks - hasAllPermissions', () => {
+    it('should return true if user has all specified permissions', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      const permissions = [Permission.MANAGE_USERS, Permission.MANAGE_PROPERTIES];
+      expect(newService.hasAllPermissions(permissions)).toBe(true);
+    });
+
+    it('should return false if user is missing any permission', () => {
+      authServiceMock.userRole$ = of('PropertyManager');
+      const newService = TestBed.inject(PermissionService);
+      const permissions = [Permission.MANAGE_USERS, Permission.MANAGE_PROPERTIES];
+      expect(newService.hasAllPermissions(permissions)).toBe(false);
+    });
+  });
+
+  describe('Permission checks - canAccess', () => {
+    it('should return computed signal for permission check', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      const canManageUsers = newService.canAccess(Permission.MANAGE_USERS);
+      expect(canManageUsers()).toBe(true);
+    });
+
+    it('should update computed signal when role changes', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      const computed = newService.canAccess(Permission.MANAGE_USERS);
+      expect(computed()).toBe(true);
+    });
+  });
+
+  describe('Organization-specific permissions - canManageOrganizations', () => {
+    it('should return true only for SUPER_ADMIN', () => {
+      authServiceMock.userRole$ = of('SUPER_ADMIN');
+      const superAdminService = TestBed.inject(PermissionService);
+      expect(superAdminService.canManageOrganizations()).toBe(true);
+
+      authServiceMock.userRole$ = of('ORG_ADMIN');
+      const orgAdminService = TestBed.inject(PermissionService);
+      expect(orgAdminService.canManageOrganizations()).toBe(false);
+
+      authServiceMock.userRole$ = of('Admin');
+      const adminService = TestBed.inject(PermissionService);
+      expect(adminService.canManageOrganizations()).toBe(false);
+    });
+  });
+
+  describe('Admin management - canManageOrgAdmins', () => {
+    it('should return true for SUPER_ADMIN and ORG_ADMIN', () => {
+      authServiceMock.userRole$ = of('SUPER_ADMIN');
+      const superAdminService = TestBed.inject(PermissionService);
+      expect(superAdminService.canManageOrgAdmins()).toBe(true);
+
+      authServiceMock.userRole$ = of('ORG_ADMIN');
+      const orgAdminService = TestBed.inject(PermissionService);
+      expect(orgAdminService.canManageOrgAdmins()).toBe(true);
+    });
+
+    it('should return false for lower-level roles', () => {
+      const roles = ['Admin', 'PropertyManager', 'Accountant'];
+
+      roles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.canManageOrgAdmins()).toBe(false);
+      });
+    });
+  });
+
+  describe('User invitation - canInviteUsers', () => {
+    it('should return true for admin roles', () => {
+      const adminRoles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin'];
+
+      adminRoles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.canInviteUsers()).toBe(true);
+      });
+    });
+
+    it('should return false for non-admin roles', () => {
+      const nonAdminRoles = ['PropertyManager', 'Accountant'];
+
+      nonAdminRoles.forEach((role) => {
+        authServiceMock.userRole$ = of(role);
+        const newService = TestBed.inject(PermissionService);
+        expect(newService.canInviteUsers()).toBe(false);
+      });
+    });
+  });
+
+  describe('Role hierarchy - isRoleHigherThan', () => {
+    it('should correctly identify higher ranked roles', () => {
+      expect(service.isRoleHigherThan('SUPER_ADMIN', 'Admin')).toBe(true);
+      expect(service.isRoleHigherThan('SUPER_ADMIN', 'ORG_ADMIN')).toBe(true);
+      expect(service.isRoleHigherThan('ORG_ADMIN', 'Admin')).toBe(true);
+      expect(service.isRoleHigherThan('Admin', 'PropertyManager')).toBe(true);
+      expect(service.isRoleHigherThan('PropertyManager', 'Accountant')).toBe(true);
+    });
+
+    it('should return false for lower or equal ranked roles', () => {
+      expect(service.isRoleHigherThan('Admin', 'SUPER_ADMIN')).toBe(false);
+      expect(service.isRoleHigherThan('PropertyManager', 'ORG_ADMIN')).toBe(false);
+      expect(service.isRoleHigherThan('Accountant', 'Admin')).toBe(false);
+    });
+
+    it('should return false for same ranked roles', () => {
+      expect(service.isRoleHigherThan('Admin', 'Admin')).toBe(false);
+      expect(service.isRoleHigherThan('SUPER_ADMIN', 'SUPER_ADMIN')).toBe(false);
+    });
+  });
+
+  describe('Role permissions - getRolePermissions', () => {
+    it('should return all permissions for SUPER_ADMIN', () => {
+      const permissions = service.getRolePermissions('SUPER_ADMIN');
+      expect(permissions.length).toBeGreaterThan(0);
+      expect(permissions).toContain(Permission.MANAGE_ORGANIZATIONS);
+      expect(permissions).toContain(Permission.MANAGE_USERS);
+      expect(permissions).toContain(Permission.MANAGE_PROPERTIES);
+    });
+
+    it('should return limited permissions for Accountant', () => {
+      const permissions = service.getRolePermissions('Accountant');
+      expect(permissions.length).toBeGreaterThan(0);
+      expect(permissions).not.toContain(Permission.MANAGE_PROPERTIES);
+      expect(permissions).not.toContain(Permission.MANAGE_USERS);
+      expect(permissions).toContain(Permission.VIEW_PAYMENTS);
+    });
+
+    it('should return permissions for all roles', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'PropertyManager', 'Accountant'] as const;
+
+      roles.forEach((role) => {
+        const permissions = service.getRolePermissions(role);
+        expect(Array.isArray(permissions)).toBe(true);
+        expect(permissions.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should not return empty array for any valid role', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'PropertyManager', 'Accountant'] as const;
+
+      roles.forEach((role) => {
+        const permissions = service.getRolePermissions(role);
+        expect(permissions.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('Convenience methods', () => {
+    it('canManageProperties should check for MANAGE_PROPERTIES permission', () => {
+      authServiceMock.userRole$ = of('PropertyManager');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.canManageProperties()).toBe(true);
+
+      authServiceMock.userRole$ = of('Accountant');
+      const accountantService = TestBed.inject(PermissionService);
+      expect(accountantService.canManageProperties()).toBe(false);
+    });
+
+    it('canManageTenants should check for MANAGE_TENANTS permission', () => {
+      authServiceMock.userRole$ = of('PropertyManager');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.canManageTenants()).toBe(true);
+
+      authServiceMock.userRole$ = of('Accountant');
+      const accountantService = TestBed.inject(PermissionService);
+      expect(accountantService.canManageTenants()).toBe(false);
+    });
+
+    it('canRecordPayments should check for RECORD_PAYMENTS permission', () => {
+      authServiceMock.userRole$ = of('PropertyManager');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.canRecordPayments()).toBe(true);
+
+      authServiceMock.userRole$ = of('Accountant');
+      const accountantService = TestBed.inject(PermissionService);
+      expect(accountantService.canRecordPayments()).toBe(false);
+    });
+
+    it('canViewReports should check for VIEW_REPORTS permission', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.canViewReports()).toBe(true);
+
+      authServiceMock.userRole$ = of('PropertyManager');
+      const pmService = TestBed.inject(PermissionService);
+      expect(pmService.canViewReports()).toBe(true);
+    });
+
+    it('canManageDocuments should check for MANAGE_DOCUMENTS permission', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.canManageDocuments()).toBe(true);
+
+      authServiceMock.userRole$ = of('Accountant');
+      const accountantService = TestBed.inject(PermissionService);
+      expect(accountantService.canManageDocuments()).toBe(false);
+    });
+  });
+
+  describe('getCurrentRole', () => {
+    it('should return the current user role', () => {
+      authServiceMock.userRole$ = of('Admin');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.getCurrentRole()).toBe('Admin');
+    });
+
+    it('should return empty string when no role is set', () => {
+      authServiceMock.userRole$ = of('');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.getCurrentRole()).toBe('');
+    });
+  });
+
+  describe('Role hierarchy validation', () => {
+    it('should match ROLE_HIERARCHY constant', () => {
+      const expectedHierarchy = {
+        SUPER_ADMIN: 0,
+        ORG_ADMIN: 1,
+        Admin: 2,
+        PropertyManager: 3,
+        Accountant: 4,
+      };
+
+      expect(ROLE_HIERARCHY).toEqual(expectedHierarchy);
+    });
+
+    it('should use consistent hierarchy in comparisons', () => {
+      // Higher rank values = lower privilege
+      expect(ROLE_HIERARCHY['SUPER_ADMIN']).toBeLessThan(ROLE_HIERARCHY['ORG_ADMIN']);
+      expect(ROLE_HIERARCHY['ORG_ADMIN']).toBeLessThan(ROLE_HIERARCHY['Admin']);
+      expect(ROLE_HIERARCHY['Admin']).toBeLessThan(ROLE_HIERARCHY['PropertyManager']);
+      expect(ROLE_HIERARCHY['PropertyManager']).toBeLessThan(ROLE_HIERARCHY['Accountant']);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle unknown role gracefully', () => {
+      authServiceMock.userRole$ = of('UnknownRole');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isSuperAdmin()).toBe(false);
+      expect(newService.hasPermission(Permission.MANAGE_USERS)).toBe(false);
+    });
+
+    it('should handle empty role string', () => {
+      authServiceMock.userRole$ = of('');
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.isSuperAdmin()).toBe(false);
+      expect(newService.isAdmin()).toBe(false);
+    });
+
+    it('should handle null role gracefully', () => {
+      authServiceMock.userRole$ = of(null);
+      const newService = TestBed.inject(PermissionService);
+      expect(newService.getCurrentRole()).toBeNull();
+    });
+  });
+
+  describe('Permission consistency', () => {
+    it('should ensure all roles have permissions defined', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'PropertyManager', 'Accountant'];
+
+      roles.forEach((role) => {
+        expect(ROLE_PERMISSIONS[role]).toBeDefined();
+        expect(Array.isArray(ROLE_PERMISSIONS[role])).toBe(true);
+      });
+    });
+
+    it('should ensure SUPER_ADMIN has most permissions', () => {
+      const superAdminPerms = ROLE_PERMISSIONS['SUPER_ADMIN'].length;
+      const orgAdminPerms = ROLE_PERMISSIONS['ORG_ADMIN'].length;
+      const adminPerms = ROLE_PERMISSIONS['Admin'].length;
+      const pmPerms = ROLE_PERMISSIONS['PropertyManager'].length;
+      const acctPerms = ROLE_PERMISSIONS['Accountant'].length;
+
+      expect(superAdminPerms).toBeGreaterThanOrEqual(orgAdminPerms);
+      expect(orgAdminPerms).toBeGreaterThanOrEqual(adminPerms);
+      expect(adminPerms).toBeGreaterThanOrEqual(pmPerms);
+      expect(pmPerms).toBeGreaterThanOrEqual(acctPerms);
+    });
+  });
+});

--- a/src/frontend/src/app/core/services/permission.service.ts
+++ b/src/frontend/src/app/core/services/permission.service.ts
@@ -5,6 +5,9 @@ import {
   hasPermission,
   hasAnyPermission,
   hasAllPermissions,
+  ROLE_HIERARCHY,
+  ROLE_PERMISSIONS,
+  UserRole,
 } from '../models/role.model';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -28,28 +31,42 @@ export class PermissionService {
    * Check if current user has a specific permission
    */
   hasPermission(permission: Permission): boolean {
-    return hasPermission(this.userRole(), permission);
+    return hasPermission(this.userRole() as UserRole, permission);
   }
 
   /**
    * Check if current user has any of the specified permissions
    */
   hasAnyPermission(permissions: Permission[]): boolean {
-    return hasAnyPermission(this.userRole(), permissions);
+    return hasAnyPermission(this.userRole() as UserRole, permissions);
   }
 
   /**
    * Check if current user has all of the specified permissions
    */
   hasAllPermissions(permissions: Permission[]): boolean {
-    return hasAllPermissions(this.userRole(), permissions);
+    return hasAllPermissions(this.userRole() as UserRole, permissions);
   }
 
   /**
    * Computed signal for checking permission
    */
   canAccess(permission: Permission) {
-    return computed(() => hasPermission(this.userRole(), permission));
+    return computed(() => hasPermission(this.userRole() as UserRole, permission));
+  }
+
+  /**
+   * Check if user is SUPER_ADMIN
+   */
+  isSuperAdmin(): boolean {
+    return this.userRole() === 'SUPER_ADMIN';
+  }
+
+  /**
+   * Check if user is ORG_ADMIN
+   */
+  isOrgAdmin(): boolean {
+    return this.userRole() === 'ORG_ADMIN';
   }
 
   /**
@@ -106,6 +123,44 @@ export class PermissionService {
    */
   canManageDocuments(): boolean {
     return this.hasPermission(Permission.MANAGE_DOCUMENTS);
+  }
+
+  /**
+   * Check if user can manage organizations (SUPER_ADMIN only)
+   */
+  canManageOrganizations(): boolean {
+    return this.hasPermission(Permission.MANAGE_ORGANIZATIONS);
+  }
+
+  /**
+   * Check if user can manage org admins
+   */
+  canManageOrgAdmins(): boolean {
+    return this.hasPermission(Permission.MANAGE_ORG_ADMINS);
+  }
+
+  /**
+   * Check if user can invite users
+   */
+  canInviteUsers(): boolean {
+    return this.hasPermission(Permission.INVITE_USERS);
+  }
+
+  /**
+   * Check if one role is higher than another in the hierarchy
+   * (lower number = higher privilege)
+   */
+  isRoleHigherThan(role1: UserRole, role2: UserRole): boolean {
+    const rank1 = ROLE_HIERARCHY[role1];
+    const rank2 = ROLE_HIERARCHY[role2];
+    return rank1 < rank2;
+  }
+
+  /**
+   * Get all permissions for a role
+   */
+  getRolePermissions(role: UserRole): Permission[] {
+    return ROLE_PERMISSIONS[role] || [];
   }
 
   /**

--- a/src/frontend/src/app/core/services/user-invitation.service.spec.ts
+++ b/src/frontend/src/app/core/services/user-invitation.service.spec.ts
@@ -1,0 +1,463 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { UserInvitationService } from './user-invitation.service';
+import { UserInvitation, InviteUserRequest } from '../models';
+
+describe('UserInvitationService', () => {
+  let service: UserInvitationService;
+  let httpMock: HttpTestingController;
+  const apiUrl = '/api/v1/organizations';
+  const invitationsUrl = '/api/v1/invitations';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [UserInvitationService],
+    });
+    service = TestBed.inject(UserInvitationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('Initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+  });
+
+  describe('sendInvitation', () => {
+    it('should send an invitation', () => {
+      const orgId = 1;
+      const inviteReq: InviteUserRequest = {
+        email: 'user@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        role: 'Admin',
+      };
+
+      const mockInvitation: UserInvitation = {
+        id: 1,
+        organizationId: orgId,
+        email: 'user@example.com',
+        role: 'Admin',
+        token: 'mock-token-123',
+        expiresAt: new Date(),
+        createdAt: new Date(),
+      };
+
+      service.sendInvitation(orgId, inviteReq).subscribe((result) => {
+        expect(result.email).toBe('user@example.com');
+        expect(result.role).toBe('Admin');
+        expect(result.token).toBe('mock-token-123');
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(inviteReq);
+      req.flush(mockInvitation);
+    });
+
+    it('should send invitation with all user roles', () => {
+      const orgId = 1;
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'PropertyManager', 'Accountant'];
+
+      roles.forEach((role) => {
+        const inviteReq: InviteUserRequest = {
+          email: `user-${role}@example.com`,
+          firstName: 'Test',
+          lastName: 'User',
+          role: role as unknown as InviteUserRequest['role'],
+        };
+
+        service.sendInvitation(orgId, inviteReq).subscribe();
+
+        const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations`);
+        expect(req.request.body.role).toBe(role);
+        req.flush({} as UserInvitation);
+      });
+    });
+
+    it('should handle duplicate email error', () => {
+      const orgId = 1;
+      const inviteReq: InviteUserRequest = {
+        email: 'existing@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        role: 'Admin',
+      };
+
+      service.sendInvitation(orgId, inviteReq).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(409);
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations`);
+      req.flush('User already exists or already invited', {
+        status: 409,
+        statusText: 'Conflict',
+      });
+    });
+
+    it('should handle invalid email error', () => {
+      const orgId = 1;
+      const inviteReq: InviteUserRequest = {
+        email: 'invalid-email',
+        firstName: 'John',
+        lastName: 'Doe',
+        role: 'Admin',
+      };
+
+      service.sendInvitation(orgId, inviteReq).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(400);
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations`);
+      req.flush('Invalid email format', { status: 400, statusText: 'Bad Request' });
+    });
+  });
+
+  describe('getPendingInvitations', () => {
+    it('should fetch pending invitations', () => {
+      const orgId = 1;
+      const mockInvitations: UserInvitation[] = [
+        {
+          id: 1,
+          organizationId: orgId,
+          email: 'user1@example.com',
+          role: 'Admin',
+          token: 'token-1',
+          expiresAt: new Date(),
+          createdAt: new Date(),
+        },
+        {
+          id: 2,
+          organizationId: orgId,
+          email: 'user2@example.com',
+          role: 'PropertyManager',
+          token: 'token-2',
+          expiresAt: new Date(),
+          createdAt: new Date(),
+        },
+      ];
+
+      service.getPendingInvitations(orgId).subscribe((result) => {
+        expect(result.invitations.length).toBe(2);
+        expect(result.total).toBe(2);
+        expect(result.invitations[0].email).toBe('user1@example.com');
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations/pending`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ invitations: mockInvitations, total: 2 });
+    });
+
+    it('should support pagination parameters', () => {
+      const orgId = 1;
+      service.getPendingInvitations(orgId, { page: 2, limit: 10 }).subscribe();
+
+      const req = httpMock.expectOne((r) =>
+        r.url.includes(`${apiUrl}/${orgId}/invitations/pending`)
+      );
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('limit')).toBe('10');
+      req.flush({ invitations: [], total: 0 });
+    });
+
+    it('should handle empty invitations list', () => {
+      const orgId = 1;
+      service.getPendingInvitations(orgId).subscribe((result) => {
+        expect(result.invitations).toEqual([]);
+        expect(result.total).toBe(0);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations/pending`);
+      req.flush({ invitations: [], total: 0 });
+    });
+
+    it('should include only page parameter when limit is not provided', () => {
+      const orgId = 1;
+      service.getPendingInvitations(orgId, { page: 1 }).subscribe();
+
+      const req = httpMock.expectOne((r) =>
+        r.url.includes(`${apiUrl}/${orgId}/invitations/pending`)
+      );
+      expect(req.request.params.get('page')).toBe('1');
+      expect(req.request.params.get('limit')).toBeNull();
+      req.flush({ invitations: [], total: 0 });
+    });
+  });
+
+  describe('revokeInvitation', () => {
+    it('should revoke an invitation', () => {
+      service.revokeInvitation(1).subscribe();
+
+      const req = httpMock.expectOne(`${invitationsUrl}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+
+    it('should handle revoking non-existent invitation', () => {
+      service.revokeInvitation(999).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(404);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/999`);
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle revoking already accepted invitation', () => {
+      service.revokeInvitation(1).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(400);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/1`);
+      req.flush('Cannot revoke accepted invitation', {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+    });
+  });
+
+  describe('acceptInvitation', () => {
+    it('should accept an invitation with password', () => {
+      const token = 'valid-token';
+      const password = 'SecurePassword123!';
+
+      const mockUser = {
+        id: 1,
+        username: 'newuser',
+        email: 'user@example.com',
+        role: 'Admin',
+        active: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+
+      service.acceptInvitation(token, password).subscribe((result) => {
+        expect(result.username).toBe('newuser');
+        expect(result.email).toBe('user@example.com');
+      });
+
+      const req = httpMock.expectOne(`${invitationsUrl}/${token}/accept`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ password });
+      req.flush(mockUser);
+    });
+
+    it('should handle invalid token', () => {
+      service.acceptInvitation('invalid-token', 'password').subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(404);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/invalid-token/accept`);
+      req.flush('Invalid or expired token', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle weak password', () => {
+      service.acceptInvitation('token', 'weak').subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(400);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/token/accept`);
+      req.flush('Password does not meet requirements', {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+    });
+
+    it('should handle expired token', () => {
+      service.acceptInvitation('expired-token', 'password').subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(410);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/expired-token/accept`);
+      req.flush('Token has expired', { status: 410, statusText: 'Gone' });
+    });
+  });
+
+  describe('resendInvitation', () => {
+    it('should resend an invitation', () => {
+      const mockInvitation: UserInvitation = {
+        id: 1,
+        organizationId: 1,
+        email: 'user@example.com',
+        role: 'Admin',
+        token: 'new-token',
+        expiresAt: new Date(),
+        createdAt: new Date(),
+      };
+
+      service.resendInvitation(1).subscribe((result) => {
+        expect(result.token).toBe('new-token');
+        expect(result.email).toBe('user@example.com');
+      });
+
+      const req = httpMock.expectOne(`${invitationsUrl}/1/resend`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({});
+      req.flush(mockInvitation);
+    });
+
+    it('should handle resending non-existent invitation', () => {
+      service.resendInvitation(999).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(404);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/999/resend`);
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle resending already accepted invitation', () => {
+      service.resendInvitation(1).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(400);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/1/resend`);
+      req.flush('Cannot resend already accepted invitation', {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+    });
+  });
+
+  describe('validateInvitationToken', () => {
+    it('should validate an invitation token', () => {
+      const token = 'valid-token';
+      const mockInvitation: UserInvitation = {
+        id: 1,
+        organizationId: 1,
+        email: 'user@example.com',
+        role: 'Admin',
+        token: token,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+        createdAt: new Date(),
+      };
+
+      service.validateInvitationToken(token).subscribe((result) => {
+        expect(result.token).toBe(token);
+        expect(result.email).toBe('user@example.com');
+      });
+
+      const req = httpMock.expectOne(`${invitationsUrl}/${token}/validate`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockInvitation);
+    });
+
+    it('should handle invalid token validation', () => {
+      service.validateInvitationToken('invalid-token').subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(404);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/invalid-token/validate`);
+      req.flush('Invalid token', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle expired token validation', () => {
+      service.validateInvitationToken('expired-token').subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(410);
+        }
+      );
+
+      const req = httpMock.expectOne(`${invitationsUrl}/expired-token/validate`);
+      req.flush('Token has expired', { status: 410, statusText: 'Gone' });
+    });
+  });
+
+  describe('Multiple concurrent requests', () => {
+    it('should handle multiple concurrent invitation operations', () => {
+      const orgId = 1;
+      const inviteReq: InviteUserRequest = {
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        role: 'Admin',
+      };
+
+      let completedRequests = 0;
+
+      service.sendInvitation(orgId, inviteReq).subscribe(() => completedRequests++);
+      service.getPendingInvitations(orgId).subscribe(() => completedRequests++);
+      service.validateInvitationToken('token').subscribe(() => completedRequests++);
+
+      const requests = httpMock.match(() => true);
+      expect(requests.length).toBe(3);
+
+      requests[0].flush({} as UserInvitation);
+      requests[1].flush({ invitations: [], total: 0 });
+      requests[2].flush({} as UserInvitation);
+
+      expect(completedRequests).toBe(3);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle network errors gracefully', () => {
+      const orgId = 1;
+      const inviteReq: InviteUserRequest = {
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        role: 'Admin',
+      };
+
+      service.sendInvitation(orgId, inviteReq).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(0);
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/${orgId}/invitations`);
+      req.error(new ErrorEvent('Network error'), {
+        status: 0,
+        statusText: 'Unknown Error',
+      });
+    });
+
+    it('should handle timeout errors', () => {
+      service.getPendingInvitations(1).subscribe(
+        () => fail('should have failed'),
+        (error) => {
+          expect(error.status).toBe(0);
+        }
+      );
+
+      const req = httpMock.expectOne((r) => r.url.includes('invitations/pending'));
+      req.flush('Request timeout', { status: 0, statusText: 'Unknown Error' });
+    });
+  });
+});

--- a/src/frontend/src/app/core/services/user-invitation.service.ts
+++ b/src/frontend/src/app/core/services/user-invitation.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { UserInvitation, InviteUserRequest } from '../models';
+import { environment } from '../../../environments/environment';
+import { User } from './auth.service';
+
+interface InvitationListResponse {
+  invitations: UserInvitation[];
+  total: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserInvitationService {
+  private http = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/organizations`;
+
+  sendInvitation(orgId: number, req: InviteUserRequest): Observable<UserInvitation> {
+    return this.http.post<UserInvitation>(`${this.apiUrl}/${orgId}/invitations`, req);
+  }
+
+  getPendingInvitations(
+    orgId: number,
+    params?: { page?: number; limit?: number }
+  ): Observable<InvitationListResponse> {
+    let httpParams = new HttpParams();
+    if (params?.page) {
+      httpParams = httpParams.set('page', params.page.toString());
+    }
+    if (params?.limit) {
+      httpParams = httpParams.set('limit', params.limit.toString());
+    }
+    return this.http.get<InvitationListResponse>(`${this.apiUrl}/${orgId}/invitations/pending`, {
+      params: httpParams,
+    });
+  }
+
+  revokeInvitation(inviteId: number): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/invitations/${inviteId}`);
+  }
+
+  acceptInvitation(token: string, password: string): Observable<User> {
+    return this.http.post<User>(`${environment.apiUrl}/invitations/${token}/accept`, {
+      password,
+    });
+  }
+
+  resendInvitation(inviteId: number): Observable<UserInvitation> {
+    return this.http.post<UserInvitation>(
+      `${environment.apiUrl}/invitations/${inviteId}/resend`,
+      {}
+    );
+  }
+
+  validateInvitationToken(token: string): Observable<UserInvitation> {
+    return this.http.get<UserInvitation>(`${environment.apiUrl}/invitations/${token}/validate`);
+  }
+}

--- a/src/frontend/src/app/features/admin/audit-logs/audit-log-viewer.ts
+++ b/src/frontend/src/app/features/admin/audit-logs/audit-log-viewer.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-audit-log-viewer',
+  standalone: true,
+  template: '<div>Audit Log Viewer Component (TODO)</div>',
+})
+export class AuditLogViewerComponent {}

--- a/src/frontend/src/app/features/admin/organization-management/organization-create.html
+++ b/src/frontend/src/app/features/admin/organization-management/organization-create.html
@@ -1,0 +1,55 @@
+<div class="organization-form-container">
+  <h1>Create New Organization</h1>
+
+  <form [formGroup]="form" (ngSubmit)="submit()" class="form">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Organization Name</mat-label>
+      <input matInput formControlName="name" required />
+      @if (form.get('name')?.hasError('required')) {
+      <mat-error>Name is required</mat-error>
+      } @if (form.get('name')?.hasError('minlength')) {
+      <mat-error>Name must be at least 3 characters</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Slug</mat-label>
+      <input matInput formControlName="slug" required />
+      <mat-hint>Auto-generated from name</mat-hint>
+      @if (form.get('slug')?.hasError('required')) {
+      <mat-error>Slug is required</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Subscription Tier</mat-label>
+      <mat-select formControlName="subscriptionTier">
+        <mat-option value="basic">Basic</mat-option>
+        <mat-option value="professional">Professional</mat-option>
+        <mat-option value="enterprise">Enterprise</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Max Users</mat-label>
+      <input matInput type="number" formControlName="maxUsers" required />
+      @if (form.get('maxUsers')?.hasError('required')) {
+      <mat-error>Max users is required</mat-error>
+      } @if (form.get('maxUsers')?.hasError('min')) {
+      <mat-error>Max users must be at least 1</mat-error>
+      }
+    </mat-form-field>
+
+    <div class="form-actions">
+      <button mat-raised-button color="primary" type="submit" [disabled]="loading || form.invalid">
+        @if (loading) {
+        <mat-spinner diameter="20"></mat-spinner>
+        <span>Creating...</span>
+        } @else {
+        <span>Create Organization</span>
+        }
+      </button>
+      <button mat-stroked-button type="button" (click)="cancel()">Cancel</button>
+    </div>
+  </form>
+</div>

--- a/src/frontend/src/app/features/admin/organization-management/organization-create.scss
+++ b/src/frontend/src/app/features/admin/organization-management/organization-create.scss
@@ -1,0 +1,30 @@
+.organization-form-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px;
+
+  h1 {
+    margin-bottom: 24px;
+    font-size: 24px;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    .full-width {
+      width: 100%;
+    }
+
+    .form-actions {
+      display: flex;
+      gap: 12px;
+      margin-top: 24px;
+
+      button {
+        flex: 1;
+      }
+    }
+  }
+}

--- a/src/frontend/src/app/features/admin/organization-management/organization-create.ts
+++ b/src/frontend/src/app/features/admin/organization-management/organization-create.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { CreateOrgRequest } from '../../../core/models';
+import { OrganizationService } from '../../../core/services/organization.service';
+
+@Component({
+  selector: 'app-organization-create',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './organization-create.html',
+  styleUrls: ['./organization-create.scss'],
+})
+export class OrganizationCreateComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private organizationService = inject(OrganizationService);
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
+
+  form!: FormGroup;
+  loading = false;
+
+  ngOnInit(): void {
+    this.initializeForm();
+  }
+
+  initializeForm(): void {
+    this.form = this.fb.group({
+      name: ['', [Validators.required, Validators.minLength(3)]],
+      slug: ['', Validators.required],
+      subscriptionTier: ['basic', Validators.required],
+      maxUsers: [10, [Validators.required, Validators.min(1)]],
+    });
+
+    // Auto-generate slug from name
+    this.form.get('name')?.valueChanges.subscribe((name: string) => {
+      const slug = name
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^\w-]/g, '');
+      this.form.patchValue({ slug }, { emitEvent: false });
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+
+    this.loading = true;
+    const req: CreateOrgRequest = this.form.value;
+
+    this.organizationService.createOrganization(req).subscribe({
+      next: () => {
+        this.snackBar.open('Organization created successfully', 'Close', { duration: 3000 });
+        this.router.navigate(['/admin/organizations']);
+      },
+      error: (error) => {
+        console.error('Error creating organization:', error);
+        this.snackBar.open('Failed to create organization', 'Close', { duration: 3000 });
+        this.loading = false;
+      },
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/admin/organizations']);
+  }
+}

--- a/src/frontend/src/app/features/admin/organization-management/organization-detail.ts
+++ b/src/frontend/src/app/features/admin/organization-management/organization-detail.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-organization-detail',
+  standalone: true,
+  template: '<div>Organization Detail Component (TODO)</div>',
+})
+export class OrganizationDetailComponent {}

--- a/src/frontend/src/app/features/admin/organization-management/organization-edit.ts
+++ b/src/frontend/src/app/features/admin/organization-management/organization-edit.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-organization-edit',
+  standalone: true,
+  template: '<div>Organization Edit Component (TODO)</div>',
+})
+export class OrganizationEditComponent {}

--- a/src/frontend/src/app/features/admin/organization-management/organization-list.html
+++ b/src/frontend/src/app/features/admin/organization-management/organization-list.html
@@ -1,0 +1,100 @@
+<div class="organization-list-container">
+  <div class="header">
+    <h1>Organizations</h1>
+    <button mat-raised-button color="primary" (click)="createOrganization()">
+      <mat-icon>add</mat-icon>
+      New Organization
+    </button>
+  </div>
+
+  <div class="search-bar">
+    <mat-form-field appearance="outline">
+      <mat-label>Search organizations</mat-label>
+      <input
+        matInput
+        placeholder="Search by name or slug..."
+        (input)="onSearchChange($event.target.value)"
+      />
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+  </div>
+
+  @if (loading()) {
+  <div class="loading">
+    <mat-spinner></mat-spinner>
+  </div>
+  } @else {
+  <div class="table-container">
+    <table mat-table [dataSource]="filteredData()" matSort class="organization-table">
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
+        <td mat-cell *matCellDef="let org">{{ org.name }}</td>
+      </ng-container>
+
+      <!-- Slug Column -->
+      <ng-container matColumnDef="slug">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Slug</th>
+        <td mat-cell *matCellDef="let org">{{ org.slug }}</td>
+      </ng-container>
+
+      <!-- Subscription Tier Column -->
+      <ng-container matColumnDef="subscriptionTier">
+        <th mat-header-cell *matHeaderCellDef>Tier</th>
+        <td mat-cell *matCellDef="let org">
+          <mat-chip [color]="getSubscriptionTierColor(org.subscriptionTier)" selected>
+            {{ org.subscriptionTier | uppercase }}
+          </mat-chip>
+        </td>
+      </ng-container>
+
+      <!-- Max Users Column -->
+      <ng-container matColumnDef="maxUsers">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Max Users</th>
+        <td mat-cell *matCellDef="let org">{{ org.maxUsers }}</td>
+      </ng-container>
+
+      <!-- Active Column -->
+      <ng-container matColumnDef="active">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Active</th>
+        <td mat-cell *matCellDef="let org">
+          <mat-icon [color]="org.active ? 'accent' : 'warn'">
+            {{ org.active ? 'check_circle' : 'cancel' }}
+          </mat-icon>
+        </td>
+      </ng-container>
+
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Actions</th>
+        <td mat-cell *matCellDef="let org">
+          <button mat-icon-button matTooltip="View" (click)="viewOrganization(org)">
+            <mat-icon>visibility</mat-icon>
+          </button>
+          <button mat-icon-button matTooltip="Edit" (click)="editOrganization(org)">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            matTooltip="Delete"
+            color="warn"
+            (click)="deleteOrganization(org)"
+          >
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+
+    <mat-paginator
+      [pageSizeOptions]="[10, 25, 50]"
+      showFirstLastButtons
+      aria-label="Select page of organizations"
+    >
+    </mat-paginator>
+  </div>
+  }
+</div>

--- a/src/frontend/src/app/features/admin/organization-management/organization-list.scss
+++ b/src/frontend/src/app/features/admin/organization-management/organization-list.scss
@@ -1,0 +1,54 @@
+.organization-list-container {
+  padding: 24px;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+
+    h1 {
+      margin: 0;
+      font-size: 28px;
+    }
+  }
+
+  .search-bar {
+    margin-bottom: 20px;
+
+    mat-form-field {
+      width: 100%;
+      max-width: 400px;
+    }
+  }
+
+  .loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 300px;
+  }
+
+  .table-container {
+    overflow-x: auto;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+  }
+
+  .organization-table {
+    width: 100%;
+
+    th {
+      background-color: #f5f5f5;
+      font-weight: 600;
+    }
+
+    tr:hover {
+      background-color: #fafafa;
+    }
+  }
+
+  mat-paginator {
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+  }
+}

--- a/src/frontend/src/app/features/admin/organization-management/organization-list.spec.ts
+++ b/src/frontend/src/app/features/admin/organization-management/organization-list.spec.ts
@@ -1,0 +1,407 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of, throwError } from 'rxjs';
+import { OrganizationListComponent } from './organization-list';
+import { OrganizationService } from '../../../core/services/organization.service';
+import { Organization } from '../../../core/models';
+
+describe('OrganizationListComponent', () => {
+  let component: OrganizationListComponent;
+  let fixture: ComponentFixture<OrganizationListComponent>;
+  let organizationService: jasmine.SpyObj<OrganizationService>;
+  let router: jasmine.SpyObj<Router>;
+  let snackBar: jasmine.SpyObj<MatSnackBar>;
+
+  const mockOrganizations: Organization[] = [
+    {
+      id: 1,
+      name: 'Org 1',
+      slug: 'org-1',
+      subscriptionTier: 'basic',
+      maxUsers: 10,
+      active: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: 2,
+      name: 'Org 2',
+      slug: 'org-2',
+      subscriptionTier: 'professional',
+      maxUsers: 50,
+      active: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: 3,
+      name: 'Inactive Org',
+      slug: 'inactive-org',
+      subscriptionTier: 'enterprise',
+      maxUsers: 1000,
+      active: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  beforeEach(async () => {
+    const organizationServiceSpy = jasmine.createSpyObj('OrganizationService', [
+      'getOrganizations',
+      'deleteOrganization',
+    ]);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    const snackBarSpy = jasmine.createSpyObj('MatSnackBar', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [OrganizationListComponent],
+      providers: [
+        { provide: OrganizationService, useValue: organizationServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: MatSnackBar, useValue: snackBarSpy },
+      ],
+    }).compileComponents();
+
+    organizationService = TestBed.inject(
+      OrganizationService
+    ) as jasmine.SpyObj<OrganizationService>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    snackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+
+    fixture = TestBed.createComponent(OrganizationListComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('Initialization', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should load organizations on init', () => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+
+      fixture.detectChanges();
+
+      expect(organizationService.getOrganizations).toHaveBeenCalled();
+      expect(component.dataSource.data).toEqual(mockOrganizations);
+    });
+
+    it('should set loading state during load', () => {
+      organizationService.getOrganizations.and.returnValue(of({ organizations: [], total: 0 }));
+
+      expect(component.loading()).toBe(false);
+      fixture.detectChanges();
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  describe('Data loading', () => {
+    it('should populate table with organizations', () => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+
+      component.loadOrganizations();
+
+      expect(component.dataSource.data).toEqual(mockOrganizations);
+      expect(component.dataSource.data.length).toBe(3);
+    });
+
+    it('should handle empty organization list', () => {
+      organizationService.getOrganizations.and.returnValue(of({ organizations: [], total: 0 }));
+
+      component.loadOrganizations();
+
+      expect(component.dataSource.data).toEqual([]);
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should handle error when loading organizations', () => {
+      organizationService.getOrganizations.and.returnValue(
+        throwError(() => new Error('Load failed'))
+      );
+
+      component.loadOrganizations();
+
+      expect(snackBar.open).toHaveBeenCalledWith('Failed to load organizations', 'Close', {
+        duration: 3000,
+      });
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should set loading to true during load', () => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+
+      component.loadOrganizations();
+
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  describe('Search functionality', () => {
+    beforeEach(() => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+      fixture.detectChanges();
+    });
+
+    it('should filter by organization name', () => {
+      component.onSearchChange('Org 1');
+
+      expect(component.searchTerm()).toBe('Org 1');
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].name).toBe('Org 1');
+    });
+
+    it('should filter by slug', () => {
+      component.onSearchChange('org-2');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].slug).toBe('org-2');
+    });
+
+    it('should be case insensitive', () => {
+      component.onSearchChange('ORG 1');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].name).toBe('Org 1');
+    });
+
+    it('should clear search results when search is empty', () => {
+      component.onSearchChange('');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(3);
+    });
+
+    it('should return empty array when no matches', () => {
+      component.onSearchChange('NonExistent');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(0);
+    });
+  });
+
+  describe('Navigation', () => {
+    it('should navigate to create organization', () => {
+      component.createOrganization();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/admin/organizations/new']);
+    });
+
+    it('should navigate to view organization detail', () => {
+      const org = mockOrganizations[0];
+      component.viewOrganization(org);
+
+      expect(router.navigate).toHaveBeenCalledWith(['/admin/organizations', 1]);
+    });
+
+    it('should navigate to edit organization', () => {
+      const org = mockOrganizations[0];
+      component.editOrganization(org);
+
+      expect(router.navigate).toHaveBeenCalledWith(['/admin/organizations', 1, 'edit']);
+    });
+  });
+
+  describe('Delete functionality', () => {
+    beforeEach(() => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+      fixture.detectChanges();
+    });
+
+    it('should delete organization on confirmation', () => {
+      const org = mockOrganizations[0];
+      spyOn(window, 'confirm').and.returnValue(true);
+      organizationService.deleteOrganization.and.returnValue(of(void 0));
+
+      component.deleteOrganization(org);
+
+      expect(organizationService.deleteOrganization).toHaveBeenCalledWith(1);
+      expect(snackBar.open).toHaveBeenCalledWith('Organization deleted successfully', 'Close', {
+        duration: 3000,
+      });
+    });
+
+    it('should not delete organization when cancelled', () => {
+      const org = mockOrganizations[0];
+      spyOn(window, 'confirm').and.returnValue(false);
+
+      component.deleteOrganization(org);
+
+      expect(organizationService.deleteOrganization).not.toHaveBeenCalled();
+    });
+
+    it('should reload organizations after delete', () => {
+      const org = mockOrganizations[0];
+      spyOn(window, 'confirm').and.returnValue(true);
+      organizationService.deleteOrganization.and.returnValue(of(void 0));
+      organizationService.getOrganizations.calls.reset();
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations.slice(1), total: 2 })
+      );
+
+      component.deleteOrganization(org);
+
+      expect(organizationService.getOrganizations).toHaveBeenCalled();
+    });
+
+    it('should show error when delete fails', () => {
+      const org = mockOrganizations[0];
+      spyOn(window, 'confirm').and.returnValue(true);
+      organizationService.deleteOrganization.and.returnValue(
+        throwError(() => new Error('Delete failed'))
+      );
+
+      component.deleteOrganization(org);
+
+      expect(snackBar.open).toHaveBeenCalledWith('Failed to delete organization', 'Close', {
+        duration: 3000,
+      });
+    });
+  });
+
+  describe('Subscription tier colors', () => {
+    it('should return primary color for basic tier', () => {
+      expect(component.getSubscriptionTierColor('basic')).toBe('primary');
+    });
+
+    it('should return accent color for professional tier', () => {
+      expect(component.getSubscriptionTierColor('professional')).toBe('accent');
+    });
+
+    it('should return warn color for enterprise tier', () => {
+      expect(component.getSubscriptionTierColor('enterprise')).toBe('warn');
+    });
+
+    it('should return empty string for unknown tier', () => {
+      expect(component.getSubscriptionTierColor('unknown')).toBe('');
+    });
+  });
+
+  describe('DisplayedColumns', () => {
+    it('should have all required columns', () => {
+      expect(component.displayedColumns).toContain('name');
+      expect(component.displayedColumns).toContain('slug');
+      expect(component.displayedColumns).toContain('subscriptionTier');
+      expect(component.displayedColumns).toContain('maxUsers');
+      expect(component.displayedColumns).toContain('active');
+      expect(component.displayedColumns).toContain('actions');
+    });
+
+    it('should have correct number of columns', () => {
+      expect(component.displayedColumns.length).toBe(6);
+    });
+  });
+
+  describe('Table functionality', () => {
+    beforeEach(() => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+      fixture.detectChanges();
+    });
+
+    it('should set dataSource with correct data', () => {
+      expect(component.dataSource.data.length).toBe(3);
+    });
+
+    it('should have paginator after view init', () => {
+      component.ngAfterViewInit();
+
+      expect(component.dataSource.paginator).toBe(component.paginator);
+    });
+
+    it('should have sort after view init', () => {
+      component.ngAfterViewInit();
+
+      expect(component.dataSource.sort).toBe(component.sort);
+    });
+  });
+
+  describe('Organization data display', () => {
+    beforeEach(() => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+      component.loadOrganizations();
+    });
+
+    it('should display organization with correct properties', () => {
+      const org = component.dataSource.data[0];
+      expect(org.id).toBe(1);
+      expect(org.name).toBe('Org 1');
+      expect(org.slug).toBe('org-1');
+      expect(org.active).toBe(true);
+    });
+
+    it('should display inactive organizations', () => {
+      const inactiveOrg = component.dataSource.data.find((o) => !o.active);
+      expect(inactiveOrg).toBeDefined();
+      expect(inactiveOrg?.name).toBe('Inactive Org');
+    });
+  });
+
+  describe('Computed properties', () => {
+    beforeEach(() => {
+      organizationService.getOrganizations.and.returnValue(
+        of({ organizations: mockOrganizations, total: 3 })
+      );
+      component.loadOrganizations();
+    });
+
+    it('should compute filtered data', () => {
+      component.searchTerm.set('Org 1');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBeGreaterThan(0);
+      expect(filtered.some((o) => o.name.includes('Org 1'))).toBe(true);
+    });
+
+    it('should update filtered data when search term changes', () => {
+      const initialFiltered = component.filteredData();
+      expect(initialFiltered.length).toBe(3);
+
+      component.searchTerm.set('org-2');
+      const updatedFiltered = component.filteredData();
+
+      expect(updatedFiltered.length).toBeLessThan(initialFiltered.length);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle http errors when loading', () => {
+      organizationService.getOrganizations.and.returnValue(
+        throwError(() => ({ status: 500, statusText: 'Server Error' }))
+      );
+
+      component.loadOrganizations();
+
+      expect(snackBar.open).toHaveBeenCalledWith('Failed to load organizations', 'Close', {
+        duration: 3000,
+      });
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should handle 403 forbidden error', () => {
+      organizationService.getOrganizations.and.returnValue(
+        throwError(() => ({ status: 403, statusText: 'Forbidden' }))
+      );
+
+      component.loadOrganizations();
+
+      expect(snackBar.open).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/src/app/features/admin/organization-management/organization-list.ts
+++ b/src/frontend/src/app/features/admin/organization-management/organization-list.ts
@@ -1,0 +1,145 @@
+import {
+  Component,
+  OnInit,
+  AfterViewInit,
+  ViewChild,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginatorModule, MatPaginator } from '@angular/material/paginator';
+import { MatSortModule, MatSort } from '@angular/material/sort';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { Organization } from '../../../core/models';
+import { OrganizationService } from '../../../core/services/organization.service';
+
+@Component({
+  selector: 'app-organization-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule,
+    MatChipsModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './organization-list.html',
+  styleUrls: ['./organization-list.scss'],
+})
+export class OrganizationListComponent implements OnInit, AfterViewInit {
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  private organizationService = inject(OrganizationService);
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
+
+  loading = signal(false);
+  searchTerm = signal('');
+  dataSource = new MatTableDataSource<Organization>();
+  displayedColumns: string[] = [
+    'name',
+    'slug',
+    'subscriptionTier',
+    'maxUsers',
+    'active',
+    'actions',
+  ];
+
+  filteredData = computed(() => {
+    const search = this.searchTerm().toLowerCase();
+    return this.dataSource.data.filter(
+      (org) => org.name.toLowerCase().includes(search) || org.slug.toLowerCase().includes(search)
+    );
+  });
+
+  ngOnInit(): void {
+    this.loadOrganizations();
+  }
+
+  ngAfterViewInit(): void {
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+    if (this.sort) {
+      this.dataSource.sort = this.sort;
+    }
+  }
+
+  loadOrganizations(): void {
+    this.loading.set(true);
+    this.organizationService.getOrganizations().subscribe({
+      next: (response) => {
+        this.dataSource.data = response.organizations;
+        this.loading.set(false);
+      },
+      error: (error) => {
+        console.error('Error loading organizations:', error);
+        this.snackBar.open('Failed to load organizations', 'Close', { duration: 3000 });
+        this.loading.set(false);
+      },
+    });
+  }
+
+  onSearchChange(value: string): void {
+    this.searchTerm.set(value);
+    this.dataSource.filter = value.toLowerCase();
+  }
+
+  createOrganization(): void {
+    this.router.navigate(['/admin/organizations/new']);
+  }
+
+  viewOrganization(org: Organization): void {
+    this.router.navigate(['/admin/organizations', org.id]);
+  }
+
+  editOrganization(org: Organization): void {
+    this.router.navigate(['/admin/organizations', org.id, 'edit']);
+  }
+
+  deleteOrganization(org: Organization): void {
+    if (confirm(`Are you sure you want to delete organization "${org.name}"?`)) {
+      this.organizationService.deleteOrganization(org.id).subscribe({
+        next: () => {
+          this.snackBar.open('Organization deleted successfully', 'Close', { duration: 3000 });
+          this.loadOrganizations();
+        },
+        error: (error) => {
+          console.error('Error deleting organization:', error);
+          this.snackBar.open('Failed to delete organization', 'Close', { duration: 3000 });
+        },
+      });
+    }
+  }
+
+  getSubscriptionTierColor(tier: string): string {
+    switch (tier) {
+      case 'basic':
+        return 'primary';
+      case 'professional':
+        return 'accent';
+      case 'enterprise':
+        return 'warn';
+      default:
+        return '';
+    }
+  }
+}

--- a/src/frontend/src/app/features/admin/user-management/admin-promotion.ts
+++ b/src/frontend/src/app/features/admin/user-management/admin-promotion.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-admin-promotion',
+  standalone: true,
+  template: '<div>Admin Promotion Component (TODO)</div>',
+})
+export class AdminPromotionComponent {}

--- a/src/frontend/src/app/features/admin/user-onboarding/bulk-import.ts
+++ b/src/frontend/src/app/features/admin/user-onboarding/bulk-import.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-bulk-import',
+  standalone: true,
+  template: '<div>Bulk Import Component (TODO)</div>',
+})
+export class BulkImportComponent {}

--- a/src/frontend/src/app/features/admin/user-onboarding/invite-user.ts
+++ b/src/frontend/src/app/features/admin/user-onboarding/invite-user.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-invite-user',
+  standalone: true,
+  template: '<div>Invite User Component (TODO)</div>',
+})
+export class InviteUserComponent {}

--- a/src/frontend/src/app/features/admin/user-onboarding/pending-invitations.ts
+++ b/src/frontend/src/app/features/admin/user-onboarding/pending-invitations.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-pending-invitations',
+  standalone: true,
+  template: '<div>Pending Invitations Component (TODO)</div>',
+})
+export class PendingInvitationsComponent {}

--- a/src/frontend/src/app/features/attachments/attachment-list/attachment-list.ts
+++ b/src/frontend/src/app/features/attachments/attachment-list/attachment-list.ts
@@ -196,8 +196,9 @@ export class AttachmentList implements OnInit {
     }
   }
 
-  editAttachment(attachment: Attachment) {
+  editAttachment(attachment: Attachment): void {
     // TODO: Implement edit attachment dialog
+    void attachment; // Suppress unused variable warning
     this.snackBar.open('Edit attachment functionality will be implemented', 'Close', {
       duration: 3000,
     });
@@ -207,6 +208,7 @@ export class AttachmentList implements OnInit {
     if (confirm(`Are you sure you want to delete "${attachment.file_name}"?`)) {
       this.attachmentService.deleteAttachment(attachment.id).subscribe({
         next: () => {
+          this.loadAttachments();
           this.snackBar.open('Attachment deleted successfully', 'Close', { duration: 3000 });
           this.loadAttachments();
         },

--- a/src/frontend/src/app/features/auth/login/login.spec.ts
+++ b/src/frontend/src/app/features/auth/login/login.spec.ts
@@ -4,16 +4,14 @@ import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Store } from '@ngrx/store';
-import { of, BehaviorSubject } from 'rxjs';
+import { of, BehaviorSubject, Subject } from 'rxjs';
 import { Login } from './login';
 import { AuthService } from '../../../core/services/auth.service';
-import { AppState } from '../../../store';
 
 describe('Login Component', () => {
   let component: Login;
   let fixture: ComponentFixture<Login>;
-  let authService: jasmine.SpyObj<AuthService>;
-  let store: jasmine.SpyObj<Store<AppState>>;
+  let authService: AuthService;
   let router: jasmine.SpyObj<Router>;
   let snackBar: jasmine.SpyObj<MatSnackBar>;
 
@@ -47,8 +45,7 @@ describe('Login Component', () => {
 
     fixture = TestBed.createComponent(Login);
     component = fixture.componentInstance;
-    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
-    store = TestBed.inject(Store) as jasmine.SpyObj<Store<AppState>>;
+    authService = TestBed.inject(AuthService);
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     snackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
 
@@ -101,6 +98,11 @@ describe('Login Component', () => {
   });
 
   it('should show error message when authentication fails', () => {
+    const errorSubject = new Subject<unknown>();
+    authService.error$ = errorSubject.asObservable();
+
+    component.ngOnInit();
+
     const error = { error: { error: 'Invalid credentials' } };
     errorSubject.next(error);
 
@@ -108,6 +110,11 @@ describe('Login Component', () => {
   });
 
   it('should show default error message when error has no specific message', () => {
+    const errorSubject = new Subject<unknown>();
+    authService.error$ = errorSubject.asObservable();
+
+    component.ngOnInit();
+
     const error = {};
     errorSubject.next(error);
 

--- a/src/frontend/src/app/features/auth/login/login.ts
+++ b/src/frontend/src/app/features/auth/login/login.ts
@@ -34,7 +34,7 @@ export class Login implements OnInit {
 
   loginForm: FormGroup;
   loading = signal(false);
-  error = signal<any>(null);
+  error = signal<unknown>(null);
 
   constructor() {
     this.loginForm = this.fb.group({
@@ -66,13 +66,12 @@ export class Login implements OnInit {
         takeUntilDestroyed(),
         filter((error) => !!error)
       )
-      .subscribe((error: any) => {
+      .subscribe((error: unknown) => {
         console.error('Login error:', error);
-        this.snackBar.open(
-          error.error?.error || 'Login failed. Please check your credentials.',
-          'Close',
-          { duration: 5000 }
-        );
+        const errorMessage =
+          (error as { error?: { error?: string } }).error?.error ||
+          'Login failed. Please check your credentials.';
+        this.snackBar.open(errorMessage, 'Close', { duration: 5000 });
       });
   }
 

--- a/src/frontend/src/app/features/auth/profile/profile.html
+++ b/src/frontend/src/app/features/auth/profile/profile.html
@@ -1,7 +1,8 @@
 <div class="profile-container">
   <h1>User Profile</h1>
 
-  <div class="profile-content" *ngIf="user">
+  @if (user) {
+  <div class="profile-content">
     <!-- User Information Card -->
     <mat-card class="user-info-card">
       <mat-card-header>
@@ -13,30 +14,32 @@
       <mat-card-content>
         <div class="user-details">
           <div class="detail-row">
-            <label>Username:</label>
-            <span>{{ user.username }}</span>
+            <label for="username">Username:</label>
+            <span id="username">{{ user.username }}</span>
           </div>
           <div class="detail-row">
-            <label>Email:</label>
-            <span>{{ user.email }}</span>
+            <label for="email">Email:</label>
+            <span id="email">{{ user.email }}</span>
           </div>
           <div class="detail-row">
-            <label>Role:</label>
-            <mat-chip [color]="getRoleColor(user.role)" selected> {{ user.role }} </mat-chip>
+            <label for="role">Role:</label>
+            <mat-chip id="role" [color]="getRoleColor(user.role)" selected>
+              {{ user.role }}
+            </mat-chip>
           </div>
           <div class="detail-row">
-            <label>Status:</label>
-            <mat-chip [color]="user.active ? 'primary' : 'warn'" selected>
+            <label for="status">Status:</label>
+            <mat-chip id="status" [color]="user.active ? 'primary' : 'warn'" selected>
               {{ user.active ? 'Active' : 'Inactive' }}
             </mat-chip>
           </div>
           <div class="detail-row">
-            <label>Member Since:</label>
-            <span>{{ formatDate(user.created_at) }}</span>
+            <label for="memberSince">Member Since:</label>
+            <span id="memberSince">{{ formatDate(user.created_at) }}</span>
           </div>
           <div class="detail-row">
-            <label>Last Updated:</label>
-            <span>{{ formatDate(user.updated_at) }}</span>
+            <label for="lastUpdated">Last Updated:</label>
+            <span id="lastUpdated">{{ formatDate(user.updated_at) }}</span>
           </div>
         </div>
       </mat-card-content>
@@ -64,7 +67,8 @@
         </div>
 
         <!-- Change Password Form -->
-        <div class="change-password-section" *ngIf="showChangePassword">
+        @if (showChangePassword) {
+        <div class="change-password-section">
           <form [formGroup]="changePasswordForm" (ngSubmit)="onChangePassword()">
             <mat-form-field appearance="outline" class="full-width">
               <mat-label>Current Password</mat-label>
@@ -75,9 +79,9 @@
                 formControlName="currentPassword"
                 placeholder="Enter your current password"
               />
-              <mat-error *ngIf="changePasswordForm.get('currentPassword')?.hasError('required')">
-                Current password is required
-              </mat-error>
+              @if (changePasswordForm.get('currentPassword')?.hasError('required')) {
+              <mat-error>Current password is required</mat-error>
+              }
             </mat-form-field>
 
             <mat-form-field appearance="outline" class="full-width">
@@ -89,12 +93,11 @@
                 formControlName="newPassword"
                 placeholder="Enter your new password"
               />
-              <mat-error *ngIf="changePasswordForm.get('newPassword')?.hasError('required')">
-                New password is required
-              </mat-error>
-              <mat-error *ngIf="changePasswordForm.get('newPassword')?.hasError('minlength')">
-                Password must be at least 8 characters long
-              </mat-error>
+              @if (changePasswordForm.get('newPassword')?.hasError('required')) {
+              <mat-error>New password is required</mat-error>
+              } @if (changePasswordForm.get('newPassword')?.hasError('minlength')) {
+              <mat-error>Password must be at least 8 characters long</mat-error>
+              }
             </mat-form-field>
 
             <mat-form-field appearance="outline" class="full-width">
@@ -106,14 +109,11 @@
                 formControlName="confirmPassword"
                 placeholder="Confirm your new password"
               />
-              <mat-error *ngIf="changePasswordForm.get('confirmPassword')?.hasError('required')">
-                Please confirm your new password
-              </mat-error>
-              <mat-error
-                *ngIf="changePasswordForm.get('confirmPassword')?.hasError('passwordMismatch')"
-              >
-                Passwords do not match
-              </mat-error>
+              @if (changePasswordForm.get('confirmPassword')?.hasError('required')) {
+              <mat-error>Please confirm your new password</mat-error>
+              } @if (changePasswordForm.get('confirmPassword')?.hasError('passwordMismatch')) {
+              <mat-error>Passwords do not match</mat-error>
+              }
             </mat-form-field>
 
             <div class="form-actions">
@@ -137,11 +137,13 @@
             </div>
           </form>
         </div>
+        }
       </mat-card-content>
     </mat-card>
   </div>
-
-  <div *ngIf="!user" class="loading-container">
+  } @if (!user) {
+  <div class="loading-container">
     <p>Loading user information...</p>
   </div>
+  }
 </div>

--- a/src/frontend/src/app/features/leases/lease-list/lease-list.ts
+++ b/src/frontend/src/app/features/leases/lease-list/lease-list.ts
@@ -99,8 +99,9 @@ export class LeaseList implements OnInit {
     return this.authService.isAdmin();
   }
 
-  editLease(lease: LeaseWithDetails) {
+  editLease(lease: LeaseWithDetails): void {
     // TODO: Implement edit lease dialog
+    void lease; // Suppress unused variable warning
     this.snackBar.open('Edit lease functionality will be implemented', 'Close', {
       duration: 3000,
     });
@@ -121,7 +122,8 @@ export class LeaseList implements OnInit {
     }
   }
 
-  viewDetails(lease: LeaseWithDetails) {
+  viewDetails(lease: LeaseWithDetails): void {
+    void lease; // Suppress unused variable warning
     // TODO: Navigate to lease details page
     this.snackBar.open('Lease details page will be implemented', 'Close', {
       duration: 3000,

--- a/src/frontend/src/app/features/properties/building-form-dialog/building-form-dialog.html
+++ b/src/frontend/src/app/features/properties/building-form-dialog/building-form-dialog.html
@@ -21,14 +21,18 @@
       <mat-label>Building Code</mat-label>
       <input matInput formControlName="building_code" placeholder="e.g., BLD-001" required />
       <mat-icon matPrefix>tag</mat-icon>
-      <mat-hint *ngIf="!isEditMode">Unique identifier for this building</mat-hint>
+      @if (!isEditMode) {
+      <mat-hint>Unique identifier for this building</mat-hint>
+      }
       <mat-error>{{ getErrorMessage('building_code') }}</mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Building Type</mat-label>
       <mat-select formControlName="building_type" required>
-        <mat-option *ngFor="let type of buildingTypes" [value]="type"> {{ type }} </mat-option>
+        @for (type of buildingTypes; track type) {
+        <mat-option [value]="type"> {{ type }} </mat-option>
+        }
       </mat-select>
       <mat-icon matPrefix>category</mat-icon>
       <mat-error>{{ getErrorMessage('building_type') }}</mat-error>

--- a/src/frontend/src/app/features/properties/building-form-dialog/building-form-dialog.ts
+++ b/src/frontend/src/app/features/properties/building-form-dialog/building-form-dialog.ts
@@ -84,6 +84,7 @@ export class BuildingFormDialogComponent implements OnInit {
 
       // Remove building_code from updates (it's immutable)
       if (this.data.mode === 'edit') {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { building_code, ...updateData } = formValue;
         this.dialogRef.close(updateData);
       } else {
@@ -135,7 +136,7 @@ export class BuildingFormDialogComponent implements OnInit {
   }
 
   private getFieldLabel(fieldName: string): string {
-    const labels: { [key: string]: string } = {
+    const labels: Record<string, string> = {
       building_name: 'Building Name',
       building_code: 'Building Code',
       building_type: 'Building Type',

--- a/src/frontend/src/app/features/properties/property-card/property-card.html
+++ b/src/frontend/src/app/features/properties/property-card/property-card.html
@@ -33,7 +33,14 @@
 
       @if (property.buildings) { @for (building of property.buildings; track building.id) {
       <mat-card class="building-card">
-        <div class="building-header" (click)="onToggleBuilding(building)">
+        <div
+          class="building-header"
+          (click)="onToggleBuilding(building)"
+          (keyup.enter)="onToggleBuilding(building)"
+          (keyup.space)="onToggleBuilding(building)"
+          tabindex="0"
+          role="button"
+        >
           <mat-icon>apartment</mat-icon>
           <div class="building-info">
             <strong>{{ building.building_name }}</strong>

--- a/src/frontend/src/app/features/properties/property-form-dialog/property-form-dialog.html
+++ b/src/frontend/src/app/features/properties/property-form-dialog/property-form-dialog.html
@@ -21,14 +21,18 @@
       <mat-label>Property Code</mat-label>
       <input matInput formControlName="property_code" placeholder="e.g., PROP-001" required />
       <mat-icon matPrefix>tag</mat-icon>
-      <mat-hint *ngIf="!isEditMode">Unique identifier for this property</mat-hint>
+      @if (!isEditMode) {
+      <mat-hint>Unique identifier for this property</mat-hint>
+      }
       <mat-error>{{ getErrorMessage('property_code') }}</mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Property Type</mat-label>
       <mat-select formControlName="property_type" required>
-        <mat-option *ngFor="let type of propertyTypes" [value]="type"> {{ type }} </mat-option>
+        @for (type of propertyTypes; track type) {
+        <mat-option [value]="type"> {{ type }} </mat-option>
+        }
       </mat-select>
       <mat-icon matPrefix>category</mat-icon>
       <mat-error>{{ getErrorMessage('property_type') }}</mat-error>

--- a/src/frontend/src/app/features/properties/property-form-dialog/property-form-dialog.ts
+++ b/src/frontend/src/app/features/properties/property-form-dialog/property-form-dialog.ts
@@ -77,6 +77,7 @@ export class PropertyFormDialogComponent implements OnInit {
 
       // Remove property_code from updates (it's immutable)
       if (this.data.mode === 'edit') {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { property_code, ...updateData } = formValue;
         this.dialogRef.close(updateData);
       } else {
@@ -121,7 +122,7 @@ export class PropertyFormDialogComponent implements OnInit {
   }
 
   private getFieldLabel(fieldName: string): string {
-    const labels: { [key: string]: string } = {
+    const labels: Record<string, string> = {
       property_name: 'Property Name',
       property_code: 'Property Code',
       address: 'Address',

--- a/src/frontend/src/app/features/properties/property-list/property-list.component.ts
+++ b/src/frontend/src/app/features/properties/property-list/property-list.component.ts
@@ -117,7 +117,7 @@ export class PropertyListComponent implements OnInit {
           return newMap;
         });
       },
-      error: (err: any) => {
+      error: (err: unknown) => {
         console.error('Error loading buildings:', err);
       },
     });
@@ -136,7 +136,7 @@ export class PropertyListComponent implements OnInit {
       next: (response: UnitListResponse) => {
         building.units = response.units;
       },
-      error: (err: any) => {
+      error: (err: unknown) => {
         console.error('Error loading units:', err);
       },
     });

--- a/src/frontend/src/app/features/properties/store/building.actions.ts
+++ b/src/frontend/src/app/features/properties/store/building.actions.ts
@@ -1,4 +1,4 @@
-import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import { createActionGroup, props } from '@ngrx/store';
 import {
   Building,
   CreateBuildingRequest,
@@ -10,23 +10,23 @@ export const BuildingActions = createActionGroup({
   events: {
     'Load Buildings': props<{ propertyId?: number; active?: boolean }>(),
     'Load Buildings Success': props<{ buildings: Building[] }>(),
-    'Load Buildings Failure': props<{ error: any }>(),
+    'Load Buildings Failure': props<{ error: unknown }>(),
 
     'Load Building': props<{ id: number }>(),
     'Load Building Success': props<{ building: Building }>(),
-    'Load Building Failure': props<{ error: any }>(),
+    'Load Building Failure': props<{ error: unknown }>(),
 
     'Create Building': props<{ request: CreateBuildingRequest }>(),
     'Create Building Success': props<{ building: Building }>(),
-    'Create Building Failure': props<{ error: any }>(),
+    'Create Building Failure': props<{ error: unknown }>(),
 
     'Update Building': props<{ id: number; request: UpdateBuildingRequest }>(),
     'Update Building Success': props<{ building: Building }>(),
-    'Update Building Failure': props<{ error: any }>(),
+    'Update Building Failure': props<{ error: unknown }>(),
 
     'Delete Building': props<{ id: number }>(),
     'Delete Building Success': props<{ id: number }>(),
-    'Delete Building Failure': props<{ error: any }>(),
+    'Delete Building Failure': props<{ error: unknown }>(),
 
     'Select Building': props<{ id: number | null }>(),
   },

--- a/src/frontend/src/app/features/properties/store/building.effects.ts
+++ b/src/frontend/src/app/features/properties/store/building.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core'; // Wait, inject is from @angular/core
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { map, mergeMap, catchError, tap } from 'rxjs/operators';
+import { map, mergeMap, catchError } from 'rxjs/operators';
 import { BuildingService } from '../../../core/services/building.service';
 import { BuildingActions } from './building.actions';
 import { MatSnackBar } from '@angular/material/snack-bar';

--- a/src/frontend/src/app/features/properties/store/building.reducer.ts
+++ b/src/frontend/src/app/features/properties/store/building.reducer.ts
@@ -6,7 +6,7 @@ import { BuildingActions } from './building.actions';
 export interface BuildingState extends EntityState<Building> {
   selectedId: number | null;
   loading: boolean;
-  error: any;
+  error: unknown;
 }
 
 export const buildingAdapter: EntityAdapter<Building> = createEntityAdapter<Building>();

--- a/src/frontend/src/app/features/properties/store/building.selectors.ts
+++ b/src/frontend/src/app/features/properties/store/building.selectors.ts
@@ -3,7 +3,7 @@ import { BuildingState, buildingAdapter } from './building.reducer';
 
 export const selectBuildingState = createFeatureSelector<BuildingState>('buildings');
 
-const { selectAll, selectEntities, selectIds, selectTotal } = buildingAdapter.getSelectors();
+const { selectAll, selectEntities } = buildingAdapter.getSelectors();
 
 export const selectAllBuildings = createSelector(selectBuildingState, selectAll);
 

--- a/src/frontend/src/app/features/properties/store/property.effects.ts
+++ b/src/frontend/src/app/features/properties/store/property.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { map, mergeMap, catchError, tap } from 'rxjs/operators';
+import { map, mergeMap, catchError } from 'rxjs/operators';
 import { PropertyService } from '../../../core/services/property.service';
 import { PropertyActions } from './property.actions';
 import { MatSnackBar } from '@angular/material/snack-bar';

--- a/src/frontend/src/app/features/properties/store/unit.actions.ts
+++ b/src/frontend/src/app/features/properties/store/unit.actions.ts
@@ -6,23 +6,23 @@ export const UnitActions = createActionGroup({
   events: {
     'Load Units': props<{ buildingId?: number; active?: boolean }>(),
     'Load Units Success': props<{ units: Unit[] }>(),
-    'Load Units Failure': props<{ error: any }>(),
+    'Load Units Failure': props<{ error: unknown }>(),
 
     'Load Unit': props<{ id: number }>(),
     'Load Unit Success': props<{ unit: Unit }>(),
-    'Load Unit Failure': props<{ error: any }>(),
+    'Load Unit Failure': props<{ error: unknown }>(),
 
     'Create Unit': props<{ request: CreateUnitRequest }>(),
     'Create Unit Success': props<{ unit: Unit }>(),
-    'Create Unit Failure': props<{ error: any }>(),
+    'Create Unit Failure': props<{ error: unknown }>(),
 
     'Update Unit': props<{ id: number; request: UpdateUnitRequest }>(),
     'Update Unit Success': props<{ unit: Unit }>(),
-    'Update Unit Failure': props<{ error: any }>(),
+    'Update Unit Failure': props<{ error: unknown }>(),
 
     'Delete Unit': props<{ id: number }>(),
     'Delete Unit Success': props<{ id: number }>(),
-    'Delete Unit Failure': props<{ error: any }>(),
+    'Delete Unit Failure': props<{ error: unknown }>(),
 
     'Select Unit': props<{ id: number | null }>(),
   },

--- a/src/frontend/src/app/features/properties/store/unit.reducer.ts
+++ b/src/frontend/src/app/features/properties/store/unit.reducer.ts
@@ -6,7 +6,7 @@ import { UnitActions } from './unit.actions';
 export interface UnitState extends EntityState<Unit> {
   selectedId: number | null;
   loading: boolean;
-  error: any;
+  error: unknown;
 }
 
 export const unitAdapter: EntityAdapter<Unit> = createEntityAdapter<Unit>();

--- a/src/frontend/src/app/features/properties/store/unit.selectors.ts
+++ b/src/frontend/src/app/features/properties/store/unit.selectors.ts
@@ -3,7 +3,7 @@ import { UnitState, unitAdapter } from './unit.reducer';
 
 export const selectUnitState = createFeatureSelector<UnitState>('units');
 
-const { selectAll, selectEntities, selectIds, selectTotal } = unitAdapter.getSelectors();
+const { selectAll, selectEntities } = unitAdapter.getSelectors();
 
 export const selectAllUnits = createSelector(selectUnitState, selectAll);
 

--- a/src/frontend/src/app/features/properties/unit-form-dialog/unit-form-dialog.html
+++ b/src/frontend/src/app/features/properties/unit-form-dialog/unit-form-dialog.html
@@ -15,7 +15,9 @@
       <mat-label>Unit Number</mat-label>
       <input matInput formControlName="unit_number" placeholder="e.g., 101, A-1, Shop-5" required />
       <mat-icon matPrefix>tag</mat-icon>
-      <mat-hint *ngIf="!isEditMode">Unique identifier for this unit</mat-hint>
+      @if (!isEditMode) {
+      <mat-hint>Unique identifier for this unit</mat-hint>
+      }
       <mat-error>{{ getErrorMessage('unit_number') }}</mat-error>
     </mat-form-field>
 
@@ -29,10 +31,12 @@
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Unit Type</mat-label>
       <mat-select formControlName="unit_type" required>
-        <mat-option *ngFor="let type of unitTypes" [value]="type">
+        @for (type of unitTypes; track type) {
+        <mat-option [value]="type">
           <mat-icon>{{ getUnitTypeIcon(type) }}</mat-icon>
           {{ type }}
         </mat-option>
+        }
       </mat-select>
       <mat-icon matPrefix>category</mat-icon>
       <mat-error>{{ getErrorMessage('unit_type') }}</mat-error>

--- a/src/frontend/src/app/features/properties/unit-form-dialog/unit-form-dialog.ts
+++ b/src/frontend/src/app/features/properties/unit-form-dialog/unit-form-dialog.ts
@@ -68,6 +68,7 @@ export class UnitFormDialogComponent implements OnInit {
 
       // Remove unit_number from updates (it's immutable)
       if (this.data.mode === 'edit') {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { unit_number, ...updateData } = formValue;
         this.dialogRef.close(updateData);
       } else {
@@ -112,7 +113,7 @@ export class UnitFormDialogComponent implements OnInit {
   }
 
   private getFieldLabel(fieldName: string): string {
-    const labels: { [key: string]: string } = {
+    const labels: Record<string, string> = {
       unit_number: 'Unit Number',
       unit_name: 'Unit Name',
       unit_type: 'Unit Type',

--- a/src/frontend/src/app/features/users/user-list/user-list.html
+++ b/src/frontend/src/app/features/users/user-list/user-list.html
@@ -1,8 +1,105 @@
 <div class="user-list-container">
-  <h1>User Management</h1>
-  <mat-card>
-    <mat-card-content>
-      <p>User management functionality will be implemented in later tasks</p>
-    </mat-card-content>
-  </mat-card>
+  <div class="header">
+    <h1>User Management</h1>
+  </div>
+
+  <div class="filters">
+    <mat-form-field appearance="outline">
+      <mat-label>Search users</mat-label>
+      <input
+        matInput
+        placeholder="Search by name or email..."
+        (input)="onSearchChange($event.target.value)"
+      />
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Filter by role</mat-label>
+      <mat-select
+        [value]="selectedRole() || ''"
+        (selectionChange)="onRoleFilterChange($event.value || null)"
+      >
+        <mat-option [value]="null">All Roles</mat-option>
+        @for (role of roles; track role) {
+        <mat-option [value]="role">{{ role }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  @if (loading()) {
+  <div class="loading">
+    <mat-spinner></mat-spinner>
+  </div>
+  } @else {
+  <div class="table-container">
+    <table mat-table [dataSource]="filteredData()" matSort class="users-table">
+      <!-- Username Column -->
+      <ng-container matColumnDef="username">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
+        <td mat-cell *matCellDef="let user">{{ user.first_name || user.username }}</td>
+      </ng-container>
+
+      <!-- Email Column -->
+      <ng-container matColumnDef="email">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
+        <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+      </ng-container>
+
+      <!-- Role Column -->
+      <ng-container matColumnDef="role">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Role</th>
+        <td mat-cell *matCellDef="let user">
+          <mat-chip [color]="getRoleColor(user.role)" selected> {{ user.role }} </mat-chip>
+        </td>
+      </ng-container>
+
+      <!-- Active Column -->
+      <ng-container matColumnDef="active">
+        <th mat-header-cell *matHeaderCellDef>Status</th>
+        <td mat-cell *matCellDef="let user">
+          <mat-icon [color]="user.active ? 'accent' : 'warn'">
+            {{ user.active ? 'check_circle' : 'cancel' }}
+          </mat-icon>
+          {{ user.active ? 'Active' : 'Inactive' }}
+        </td>
+      </ng-container>
+
+      <!-- Created At Column -->
+      <ng-container matColumnDef="created_at">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Created</th>
+        <td mat-cell *matCellDef="let user">{{ user.created_at | date: 'short' }}</td>
+      </ng-container>
+
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Actions</th>
+        <td mat-cell *matCellDef="let user">
+          @if (canPromoteUsers()) {
+          <button mat-icon-button matTooltip="Promote/Demote" (click)="promoteUser(user)">
+            <mat-icon>trending_up</mat-icon>
+          </button>
+          }
+          <button mat-icon-button matTooltip="Deactivate" (click)="deactivateUser(user)">
+            <mat-icon>block</mat-icon>
+          </button>
+          <button mat-icon-button matTooltip="Delete" color="warn" (click)="deleteUser(user)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+
+    <mat-paginator
+      [pageSizeOptions]="[10, 25, 50]"
+      showFirstLastButtons
+      aria-label="Select page of users"
+    >
+    </mat-paginator>
+  </div>
+  }
 </div>

--- a/src/frontend/src/app/features/users/user-list/user-list.scss
+++ b/src/frontend/src/app/features/users/user-list/user-list.scss
@@ -1,3 +1,54 @@
 .user-list-container {
-  padding: 20px;
+  padding: 24px;
+
+  .header {
+    margin-bottom: 24px;
+
+    h1 {
+      margin: 0;
+      font-size: 28px;
+    }
+  }
+
+  .filters {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+
+    mat-form-field {
+      flex: 1;
+      min-width: 200px;
+    }
+  }
+
+  .loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 300px;
+  }
+
+  .table-container {
+    overflow-x: auto;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+  }
+
+  .users-table {
+    width: 100%;
+
+    th {
+      background-color: #f5f5f5;
+      font-weight: 600;
+    }
+
+    tr:hover {
+      background-color: #fafafa;
+    }
+  }
+
+  mat-paginator {
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+  }
 }

--- a/src/frontend/src/app/features/users/user-list/user-list.spec.ts
+++ b/src/frontend/src/app/features/users/user-list/user-list.spec.ts
@@ -1,0 +1,452 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of, throwError } from 'rxjs';
+import { UserList } from './user-list';
+import { OrganizationService } from '../../../core/services/organization.service';
+import { PermissionService } from '../../../core/services/permission.service';
+import { User } from '../../../core/services/auth.service';
+
+describe('UserList Component', () => {
+  let component: UserList;
+  let fixture: ComponentFixture<UserList>;
+  let organizationService: jasmine.SpyObj<OrganizationService>;
+  let permissionService: jasmine.SpyObj<PermissionService>;
+  let snackBar: jasmine.SpyObj<MatSnackBar>;
+
+  const mockUsers: User[] = [
+    {
+      id: 1,
+      username: 'john_doe',
+      email: 'john@example.com',
+      role: 'Admin',
+      active: true,
+      created_at: '2026-04-01T10:00:00Z',
+      updated_at: '2026-04-01T10:00:00Z',
+    },
+    {
+      id: 2,
+      username: 'jane_smith',
+      email: 'jane@example.com',
+      role: 'PropertyManager',
+      active: true,
+      created_at: '2026-04-01T10:00:00Z',
+      updated_at: '2026-04-01T10:00:00Z',
+    },
+    {
+      id: 3,
+      username: 'bob_accountant',
+      email: 'bob@example.com',
+      role: 'Accountant',
+      active: false,
+      created_at: '2026-04-01T10:00:00Z',
+      updated_at: '2026-04-01T10:00:00Z',
+    },
+  ];
+
+  const mockOrganization = {
+    id: 1,
+    name: 'Test Org',
+    slug: 'test-org',
+    subscriptionTier: 'professional' as const,
+    maxUsers: 50,
+    active: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const organizationServiceSpy = jasmine.createSpyObj('OrganizationService', [
+      'getOrganizationUsers',
+      'getCurrentOrganization',
+    ]);
+    const permissionServiceSpy = jasmine.createSpyObj('PermissionService', ['canManageOrgAdmins']);
+    const snackBarSpy = jasmine.createSpyObj('MatSnackBar', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [UserList],
+      providers: [
+        { provide: OrganizationService, useValue: organizationServiceSpy },
+        { provide: PermissionService, useValue: permissionServiceSpy },
+        { provide: MatSnackBar, useValue: snackBarSpy },
+      ],
+    }).compileComponents();
+
+    organizationService = TestBed.inject(
+      OrganizationService
+    ) as jasmine.SpyObj<OrganizationService>;
+    permissionService = TestBed.inject(PermissionService) as jasmine.SpyObj<PermissionService>;
+    snackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+
+    fixture = TestBed.createComponent(UserList);
+    component = fixture.componentInstance;
+  });
+
+  describe('Initialization', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should load users on init', () => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+
+      fixture.detectChanges();
+
+      expect(organizationService.getOrganizationUsers).toHaveBeenCalledWith(1);
+      expect(component.dataSource.data).toEqual(mockUsers);
+    });
+
+    it('should show error when no organization selected', () => {
+      organizationService.getCurrentOrganization.and.returnValue(null);
+
+      component.loadUsers();
+
+      expect(snackBar.open).toHaveBeenCalledWith('No organization selected', 'Close', {
+        duration: 3000,
+      });
+    });
+  });
+
+  describe('Data loading', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+    });
+
+    it('should populate table with users', () => {
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+
+      component.loadUsers();
+
+      expect(component.dataSource.data).toEqual(mockUsers);
+      expect(component.dataSource.data.length).toBe(3);
+    });
+
+    it('should handle empty users list', () => {
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: [], total: 0 }));
+
+      component.loadUsers();
+
+      expect(component.dataSource.data).toEqual([]);
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should handle error when loading users', () => {
+      organizationService.getOrganizationUsers.and.returnValue(
+        throwError(() => new Error('Load failed'))
+      );
+
+      component.loadUsers();
+
+      expect(snackBar.open).toHaveBeenCalledWith('Failed to load users', 'Close', {
+        duration: 3000,
+      });
+    });
+  });
+
+  describe('Search functionality', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+      component.loadUsers();
+    });
+
+    it('should filter by username', () => {
+      component.onSearchChange('john');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].username).toBe('john_doe');
+    });
+
+    it('should filter by email', () => {
+      component.onSearchChange('jane@example.com');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].email).toBe('jane@example.com');
+    });
+
+    it('should be case insensitive', () => {
+      component.onSearchChange('JOHN');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+    });
+
+    it('should return all users when search is empty', () => {
+      component.onSearchChange('');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(3);
+    });
+
+    it('should return empty array when no matches', () => {
+      component.onSearchChange('nonexistent@example.com');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(0);
+    });
+  });
+
+  describe('Role filtering', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+      component.loadUsers();
+    });
+
+    it('should filter by Admin role', () => {
+      component.onRoleFilterChange('Admin');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].role).toBe('Admin');
+    });
+
+    it('should filter by PropertyManager role', () => {
+      component.onRoleFilterChange('PropertyManager');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].role).toBe('PropertyManager');
+    });
+
+    it('should show all users when filter is cleared', () => {
+      component.onRoleFilterChange(null);
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(3);
+    });
+
+    it('should return empty when filtering for non-existent role', () => {
+      component.onRoleFilterChange('NonExistentRole');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(0);
+    });
+  });
+
+  describe('Combined search and filter', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+      component.loadUsers();
+    });
+
+    it('should apply both search and role filter', () => {
+      component.onSearchChange('jane');
+      component.onRoleFilterChange('PropertyManager');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].username).toBe('jane_smith');
+      expect(filtered[0].role).toBe('PropertyManager');
+    });
+
+    it('should return empty when search and filter have no intersection', () => {
+      component.onSearchChange('john');
+      component.onRoleFilterChange('PropertyManager');
+
+      const filtered = component.filteredData();
+      expect(filtered.length).toBe(0);
+    });
+  });
+
+  describe('User actions', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+      component.loadUsers();
+    });
+
+    it('should call deactivateUser', () => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      const user = mockUsers[0];
+
+      component.deactivateUser(user);
+
+      expect(window.confirm).toHaveBeenCalled();
+      expect(snackBar.open).toHaveBeenCalled();
+    });
+
+    it('should not deactivate when cancelled', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      const user = mockUsers[0];
+      snackBar.open.calls.reset();
+
+      component.deactivateUser(user);
+
+      expect(snackBar.open).not.toHaveBeenCalled();
+    });
+
+    it('should call deleteUser', () => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      const user = mockUsers[0];
+
+      component.deleteUser(user);
+
+      expect(window.confirm).toHaveBeenCalled();
+      expect(snackBar.open).toHaveBeenCalled();
+    });
+
+    it('should call promoteUser', () => {
+      permissionService.canManageOrgAdmins.and.returnValue(true);
+      const user = mockUsers[0];
+
+      component.promoteUser(user);
+
+      expect(snackBar.open).toHaveBeenCalled();
+    });
+  });
+
+  describe('Role colors', () => {
+    it('should return warn color for SUPER_ADMIN', () => {
+      expect(component.getRoleColor('SUPER_ADMIN')).toBe('warn');
+    });
+
+    it('should return accent color for ORG_ADMIN', () => {
+      expect(component.getRoleColor('ORG_ADMIN')).toBe('accent');
+    });
+
+    it('should return primary color for Admin', () => {
+      expect(component.getRoleColor('Admin')).toBe('primary');
+    });
+
+    it('should return primary color for PropertyManager', () => {
+      expect(component.getRoleColor('PropertyManager')).toBe('primary');
+    });
+
+    it('should return accent color for Accountant', () => {
+      expect(component.getRoleColor('Accountant')).toBe('accent');
+    });
+
+    it('should return empty string for unknown role', () => {
+      expect(component.getRoleColor('UnknownRole')).toBe('');
+    });
+  });
+
+  describe('Permissions', () => {
+    it('should check if user can promote users', () => {
+      permissionService.canManageOrgAdmins.and.returnValue(true);
+
+      expect(component.canPromoteUsers()).toBe(true);
+    });
+
+    it('should show promote button only when allowed', () => {
+      permissionService.canManageOrgAdmins.and.returnValue(false);
+
+      expect(component.canPromoteUsers()).toBe(false);
+    });
+  });
+
+  describe('DisplayedColumns', () => {
+    it('should have all required columns', () => {
+      expect(component.displayedColumns).toContain('username');
+      expect(component.displayedColumns).toContain('email');
+      expect(component.displayedColumns).toContain('role');
+      expect(component.displayedColumns).toContain('active');
+      expect(component.displayedColumns).toContain('created_at');
+      expect(component.displayedColumns).toContain('actions');
+    });
+
+    it('should have correct number of columns', () => {
+      expect(component.displayedColumns.length).toBe(6);
+    });
+  });
+
+  describe('Table functionality', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+      component.loadUsers();
+    });
+
+    it('should have paginator after view init', () => {
+      component.ngAfterViewInit();
+
+      expect(component.dataSource.paginator).toBe(component.paginator);
+    });
+
+    it('should have sort after view init', () => {
+      component.ngAfterViewInit();
+
+      expect(component.dataSource.sort).toBe(component.sort);
+    });
+  });
+
+  describe('User data display', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+      organizationService.getOrganizationUsers.and.returnValue(of({ users: mockUsers, total: 3 }));
+      component.loadUsers();
+    });
+
+    it('should display user with correct properties', () => {
+      const user = component.dataSource.data[0];
+      expect(user.id).toBe(1);
+      expect(user.username).toBe('john_doe');
+      expect(user.email).toBe('john@example.com');
+      expect(user.role).toBe('Admin');
+    });
+
+    it('should display inactive users', () => {
+      const inactiveUser = component.dataSource.data.find((u) => !u.active);
+      expect(inactiveUser).toBeDefined();
+      expect(inactiveUser?.active).toBe(false);
+    });
+
+    it('should display first_name when available', () => {
+      const userWithName = { ...mockUsers[0], first_name: 'John' };
+      organizationService.getOrganizationUsers.and.returnValue(
+        of({ users: [userWithName], total: 1 })
+      );
+
+      component.loadUsers();
+
+      // The component uses first_name || username pattern
+      expect(component.dataSource.data[0].first_name).toBe('John');
+    });
+  });
+
+  describe('Error handling', () => {
+    beforeEach(() => {
+      organizationService.getCurrentOrganization.and.returnValue(mockOrganization);
+    });
+
+    it('should handle http errors when loading', () => {
+      organizationService.getOrganizationUsers.and.returnValue(
+        throwError(() => ({ status: 500, statusText: 'Server Error' }))
+      );
+
+      component.loadUsers();
+
+      expect(snackBar.open).toHaveBeenCalledWith('Failed to load users', 'Close', {
+        duration: 3000,
+      });
+    });
+
+    it('should handle 403 forbidden error', () => {
+      organizationService.getOrganizationUsers.and.returnValue(
+        throwError(() => ({ status: 403, statusText: 'Forbidden' }))
+      );
+
+      component.loadUsers();
+
+      expect(snackBar.open).toHaveBeenCalled();
+    });
+  });
+
+  describe('Roles list', () => {
+    it('should include all available roles', () => {
+      expect(component.roles).toContain('SUPER_ADMIN');
+      expect(component.roles).toContain('ORG_ADMIN');
+      expect(component.roles).toContain('Admin');
+      expect(component.roles).toContain('PropertyManager');
+      expect(component.roles).toContain('Accountant');
+    });
+
+    it('should have correct number of roles', () => {
+      expect(component.roles.length).toBe(5);
+    });
+  });
+});

--- a/src/frontend/src/app/features/users/user-list/user-list.ts
+++ b/src/frontend/src/app/features/users/user-list/user-list.ts
@@ -1,12 +1,155 @@
-import { Component } from '@angular/core';
-
-import { MatCardModule } from '@angular/material/card';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  inject,
+  signal,
+  computed,
+  AfterViewInit,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginatorModule, MatPaginator } from '@angular/material/paginator';
+import { MatSortModule, MatSort } from '@angular/material/sort';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { User } from '../../../core/services/auth.service';
+import { OrganizationService } from '../../../core/services/organization.service';
+import { PermissionService } from '../../../core/services/permission.service';
 
 @Component({
   selector: 'app-user-list',
   standalone: true,
-  imports: [MatCardModule],
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
+    MatSelectModule,
+    MatSnackBarModule,
+    MatTooltipModule,
+  ],
   templateUrl: './user-list.html',
   styleUrls: ['./user-list.scss'],
 })
-export class UserList {}
+export class UserList implements OnInit, AfterViewInit {
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  private organizationService = inject(OrganizationService);
+  private permissionService = inject(PermissionService);
+  private snackBar = inject(MatSnackBar);
+
+  loading = signal(false);
+  searchTerm = signal('');
+  selectedRole = signal<string | null>(null);
+  dataSource = new MatTableDataSource<User>();
+  displayedColumns: string[] = ['username', 'email', 'role', 'active', 'created_at', 'actions'];
+
+  roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin', 'PropertyManager', 'Accountant'];
+
+  filteredData = computed(() => {
+    const search = this.searchTerm().toLowerCase();
+    const role = this.selectedRole();
+
+    return this.dataSource.data.filter((user) => {
+      const matchesSearch =
+        user.username.toLowerCase().includes(search) || user.email.toLowerCase().includes(search);
+      const matchesRole = !role || user.role === role;
+      return matchesSearch && matchesRole;
+    });
+  });
+
+  canPromoteUsers = computed(() => this.permissionService.canManageOrgAdmins());
+
+  ngOnInit(): void {
+    this.loadUsers();
+  }
+
+  ngAfterViewInit(): void {
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+    if (this.sort) {
+      this.dataSource.sort = this.sort;
+    }
+  }
+
+  loadUsers(): void {
+    const currentOrg = this.organizationService.getCurrentOrganization();
+    if (!currentOrg) {
+      this.snackBar.open('No organization selected', 'Close', { duration: 3000 });
+      return;
+    }
+
+    this.loading.set(true);
+    this.organizationService.getOrganizationUsers(currentOrg.id).subscribe({
+      next: (response) => {
+        this.dataSource.data = response.users;
+        this.loading.set(false);
+      },
+      error: (error) => {
+        console.error('Error loading users:', error);
+        this.snackBar.open('Failed to load users', 'Close', { duration: 3000 });
+        this.loading.set(false);
+      },
+    });
+  }
+
+  onSearchChange(value: string): void {
+    this.searchTerm.set(value);
+  }
+
+  onRoleFilterChange(role: string | null): void {
+    this.selectedRole.set(role);
+  }
+
+  deactivateUser(user: User): void {
+    if (confirm(`Are you sure you want to deactivate ${user.username}?`)) {
+      this.snackBar.open('User deactivation would be implemented here', 'Close', {
+        duration: 3000,
+      });
+    }
+  }
+
+  deleteUser(user: User): void {
+    if (confirm(`Are you sure you want to delete ${user.username}?`)) {
+      this.snackBar.open('User deletion would be implemented here', 'Close', { duration: 3000 });
+    }
+  }
+
+  promoteUser(user: User): void {
+    void user; // Suppress unused variable warning
+    this.snackBar.open('User promotion dialog would open here', 'Close', { duration: 3000 });
+  }
+
+  getRoleColor(role: string): string {
+    switch (role) {
+      case 'SUPER_ADMIN':
+        return 'warn';
+      case 'ORG_ADMIN':
+        return 'accent';
+      case 'Admin':
+        return 'primary';
+      case 'PropertyManager':
+        return 'primary';
+      case 'Accountant':
+        return 'accent';
+      default:
+        return '';
+    }
+  }
+}

--- a/src/frontend/src/app/store/auth/auth.actions.ts
+++ b/src/frontend/src/app/store/auth/auth.actions.ts
@@ -2,7 +2,6 @@ import { createAction, props } from '@ngrx/store';
 import {
   LoginRequest,
   LoginResponse,
-  User,
   ChangePasswordRequest,
   ResetPasswordRequest,
 } from '../../core/services/auth.service';
@@ -15,14 +14,14 @@ export const loginSuccess = createAction(
   props<{ response: LoginResponse }>()
 );
 
-export const loginFailure = createAction('[Auth] Login Failure', props<{ error: any }>());
+export const loginFailure = createAction('[Auth] Login Failure', props<{ error: unknown }>());
 
 // Logout Actions
 export const logout = createAction('[Auth] Logout');
 
 export const logoutSuccess = createAction('[Auth] Logout Success');
 
-export const logoutFailure = createAction('[Auth] Logout Failure', props<{ error: any }>());
+export const logoutFailure = createAction('[Auth] Logout Failure', props<{ error: unknown }>());
 
 // Token Refresh Actions
 export const refreshToken = createAction('[Auth] Refresh Token');
@@ -34,7 +33,7 @@ export const refreshTokenSuccess = createAction(
 
 export const refreshTokenFailure = createAction(
   '[Auth] Refresh Token Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Password Management Actions
@@ -50,7 +49,7 @@ export const changePasswordSuccess = createAction(
 
 export const changePasswordFailure = createAction(
   '[Auth] Change Password Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 export const resetPassword = createAction(
@@ -65,7 +64,7 @@ export const resetPasswordSuccess = createAction(
 
 export const resetPasswordFailure = createAction(
   '[Auth] Reset Password Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Initialization Actions

--- a/src/frontend/src/app/store/auth/auth.effects.spec.ts
+++ b/src/frontend/src/app/store/auth/auth.effects.spec.ts
@@ -6,7 +6,6 @@ import { Action } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { AuthEffects } from './auth.effects';
 import * as AuthActions from './auth.actions';
-import { environment } from '../../../environments/environment';
 
 describe('AuthEffects', () => {
   let effects: AuthEffects;
@@ -64,7 +63,9 @@ describe('AuthEffects', () => {
 
       effects.login$.subscribe((result) => {
         expect(result.type).toBe(AuthActions.loginSuccess.type);
-        expect((result as any).response.user.username).toBe('demo');
+        expect(
+          (result as unknown as { response: { user: { username: string } } }).response.user.username
+        ).toBe('demo');
         done();
       });
     });
@@ -78,7 +79,9 @@ describe('AuthEffects', () => {
 
       effects.login$.subscribe((result) => {
         expect(result.type).toBe(AuthActions.loginFailure.type);
-        expect((result as any).error.error).toBe('Invalid demo credentials');
+        expect((result as unknown as { error: { error: string } }).error.error).toBe(
+          'Invalid demo credentials'
+        );
         done();
       });
     });
@@ -148,7 +151,9 @@ describe('AuthEffects', () => {
 
       effects.refreshToken$.subscribe((result) => {
         expect(result.type).toBe(AuthActions.refreshTokenSuccess.type);
-        expect((result as any).response.user).toEqual(mockLoginResponse.user);
+        expect(
+          (result as unknown as { response: { user: typeof mockLoginResponse.user } }).response.user
+        ).toEqual(mockLoginResponse.user);
         done();
       });
     });
@@ -159,7 +164,7 @@ describe('AuthEffects', () => {
 
       effects.refreshToken$.subscribe((result) => {
         expect(result.type).toBe(AuthActions.refreshTokenFailure.type);
-        expect((result as any).error).toBe('No refresh token available');
+        expect((result as unknown as { error: string }).error).toBe('No refresh token available');
         done();
       });
     });
@@ -213,7 +218,9 @@ describe('AuthEffects', () => {
 
       effects.changePassword$.subscribe((result) => {
         expect(result.type).toBe(AuthActions.changePasswordSuccess.type);
-        expect((result as any).message).toBe('Password changed successfully');
+        expect((result as unknown as { message: string }).message).toBe(
+          'Password changed successfully'
+        );
         done();
       });
     });
@@ -228,7 +235,7 @@ describe('AuthEffects', () => {
 
       effects.resetPassword$.subscribe((result) => {
         expect(result.type).toBe(AuthActions.resetPasswordSuccess.type);
-        expect((result as any).message).toBe(
+        expect((result as unknown as { message: string }).message).toBe(
           'If the email exists, a password reset link has been sent'
         );
         done();

--- a/src/frontend/src/app/store/auth/auth.effects.ts
+++ b/src/frontend/src/app/store/auth/auth.effects.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { map, exhaustMap, catchError, tap } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import * as AuthActions from './auth.actions';
+import { LoginResponse } from '../../core/services/auth.service';
 
 @Injectable()
 export class AuthEffects {
@@ -30,6 +31,7 @@ export class AuthEffects {
         }
 
         // Production API call
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return this.http.post<any>(`${environment.apiUrl}/auth/login`, credentials).pipe(
           map((response) => AuthActions.loginSuccess({ response })),
           catchError((error) => of(AuthActions.loginFailure({ error })))
@@ -114,6 +116,7 @@ export class AuthEffects {
 
         // Production API call
         const request = { refresh_token: refreshToken };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return this.http.post<any>(`${environment.apiUrl}/auth/refresh`, request).pipe(
           map((response) => AuthActions.refreshTokenSuccess({ response })),
           catchError((error) => of(AuthActions.refreshTokenFailure({ error })))
@@ -171,6 +174,7 @@ export class AuthEffects {
         }
 
         // Production API call
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return this.http.post<any>(`${environment.apiUrl}/auth/change-password`, request).pipe(
           map((response) => AuthActions.changePasswordSuccess({ message: response.message })),
           catchError((error) => of(AuthActions.changePasswordFailure({ error })))
@@ -193,6 +197,7 @@ export class AuthEffects {
         }
 
         // Production API call
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return this.http.post<any>(`${environment.apiUrl}/auth/reset-password`, request).pipe(
           map((response) => AuthActions.resetPasswordSuccess({ message: response.message })),
           catchError((error) => of(AuthActions.resetPasswordFailure({ error })))
@@ -206,7 +211,7 @@ export class AuthEffects {
     return false; // Set to false for production
   }
 
-  private createDemoResponse(suffix = ''): any {
+  private createDemoResponse(suffix = ''): LoginResponse {
     const user = localStorage.getItem('tenantly_user');
     const existingUser = user ? JSON.parse(user) : null;
 

--- a/src/frontend/src/app/store/auth/auth.reducer.ts
+++ b/src/frontend/src/app/store/auth/auth.reducer.ts
@@ -85,13 +85,17 @@ export const authReducer = createReducer(
   })),
 
   // Logout
-  on(AuthActions.logout, (state) => ({
-    ...state,
+  on(AuthActions.logout, () => ({
+    user: null,
+    token: null,
+    refreshToken: null,
+    expiresAt: null,
+    isAuthenticated: false,
     loading: true,
     error: null,
   })),
 
-  on(AuthActions.logoutSuccess, (state) => ({
+  on(AuthActions.logoutSuccess, () => ({
     user: null,
     token: null,
     refreshToken: null,

--- a/src/frontend/src/app/store/auth/auth.selectors.spec.ts
+++ b/src/frontend/src/app/store/auth/auth.selectors.spec.ts
@@ -1,250 +1,159 @@
-import * as AuthSelectors from './auth.selectors';
-import { AuthState } from './auth.reducer';
-import { AppState } from '../index';
+import {
+  selectUserRole,
+  selectUserOrganizationId,
+  selectIsSuperAdmin,
+  selectIsOrgAdmin,
+  selectCanManageUsers,
+  selectCanManageOrganizations,
+  selectCanInviteUsers,
+} from './auth.selectors';
+import { User } from '../../core/services/auth.service';
 
 describe('Auth Selectors', () => {
-  const mockUser = {
+  const mockUser: User = {
     id: 1,
     username: 'testuser',
     email: 'test@example.com',
     role: 'Admin',
+    organization_id: 5,
+    first_name: 'Test',
+    last_name: 'User',
     active: true,
-    created_at: '2023-01-01T00:00:00Z',
-    updated_at: '2023-01-01T00:00:00Z',
+    created_at: '2026-04-01',
+    updated_at: '2026-04-01',
   };
-
-  const mockAuthState: AuthState = {
-    user: mockUser,
-    token: 'test-token',
-    refreshToken: 'test-refresh-token',
-    expiresAt: '2099-12-31T23:59:59Z',
-    isAuthenticated: true,
-    loading: false,
-    error: null,
-  };
-
-  const mockAppState: AppState = {
-    auth: mockAuthState,
-  };
-
-  describe('selectAuthState', () => {
-    it('should select the auth state', () => {
-      const result = AuthSelectors.selectAuthState(mockAppState);
-      expect(result).toEqual(mockAuthState);
-    });
-  });
-
-  describe('selectUser', () => {
-    it('should select the user', () => {
-      const result = AuthSelectors.selectUser.projector(mockAuthState);
-      expect(result).toEqual(mockUser);
-    });
-
-    it('should return null when user is null', () => {
-      const state = { ...mockAuthState, user: null };
-      const result = AuthSelectors.selectUser.projector(state);
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('selectToken', () => {
-    it('should select the token', () => {
-      const result = AuthSelectors.selectToken.projector(mockAuthState);
-      expect(result).toBe('test-token');
-    });
-  });
-
-  describe('selectRefreshToken', () => {
-    it('should select the refresh token', () => {
-      const result = AuthSelectors.selectRefreshToken.projector(mockAuthState);
-      expect(result).toBe('test-refresh-token');
-    });
-  });
-
-  describe('selectIsAuthenticated', () => {
-    it('should select the authentication status', () => {
-      const result = AuthSelectors.selectIsAuthenticated.projector(mockAuthState);
-      expect(result).toBe(true);
-    });
-
-    it('should return false when not authenticated', () => {
-      const state = { ...mockAuthState, isAuthenticated: false };
-      const result = AuthSelectors.selectIsAuthenticated.projector(state);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectAuthLoading', () => {
-    it('should select the loading state', () => {
-      const result = AuthSelectors.selectAuthLoading.projector(mockAuthState);
-      expect(result).toBe(false);
-    });
-
-    it('should return true when loading', () => {
-      const state = { ...mockAuthState, loading: true };
-      const result = AuthSelectors.selectAuthLoading.projector(state);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe('selectAuthError', () => {
-    it('should select the error', () => {
-      const result = AuthSelectors.selectAuthError.projector(mockAuthState);
-      expect(result).toBeNull();
-    });
-
-    it('should return error when present', () => {
-      const error = { message: 'Test error' };
-      const state = { ...mockAuthState, error };
-      const result = AuthSelectors.selectAuthError.projector(state);
-      expect(result).toEqual(error);
-    });
-  });
 
   describe('selectUserRole', () => {
-    it('should select the user role', () => {
-      const result = AuthSelectors.selectUserRole.projector(mockUser);
+    it('should extract user role from state', () => {
+      const result = selectUserRole.projector(mockUser);
       expect(result).toBe('Admin');
     });
 
     it('should return empty string when user is null', () => {
-      const result = AuthSelectors.selectUserRole.projector(null);
+      const result = selectUserRole.projector(null);
       expect(result).toBe('');
     });
   });
 
-  describe('selectIsAdmin', () => {
-    it('should return true for Admin role', () => {
-      const result = AuthSelectors.selectIsAdmin.projector('Admin');
+  describe('selectUserOrganizationId', () => {
+    it('should extract organization_id from user', () => {
+      const result = selectUserOrganizationId.projector(mockUser);
+      expect(result).toBe(5);
+    });
+
+    it('should return null when user is null', () => {
+      const result = selectUserOrganizationId.projector(null);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when organization_id is not set', () => {
+      const userWithoutOrg = { ...mockUser, organization_id: undefined };
+      const result = selectUserOrganizationId.projector(userWithoutOrg);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('selectIsSuperAdmin', () => {
+    it('should return true when role is SUPER_ADMIN', () => {
+      const result = selectIsSuperAdmin.projector('SUPER_ADMIN');
       expect(result).toBe(true);
     });
 
-    it('should return false for non-Admin role', () => {
-      const result = AuthSelectors.selectIsAdmin.projector('PropertyManager');
+    it('should return false when role is not SUPER_ADMIN', () => {
+      const result = selectIsSuperAdmin.projector('Admin');
       expect(result).toBe(false);
     });
   });
 
-  describe('selectIsPropertyManager', () => {
-    it('should return true for PropertyManager role', () => {
-      const result = AuthSelectors.selectIsPropertyManager.projector('PropertyManager');
+  describe('selectIsOrgAdmin', () => {
+    it('should return true when role is ORG_ADMIN', () => {
+      const result = selectIsOrgAdmin.projector('ORG_ADMIN');
       expect(result).toBe(true);
     });
 
-    it('should return false for non-PropertyManager role', () => {
-      const result = AuthSelectors.selectIsPropertyManager.projector('Admin');
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectIsAccountant', () => {
-    it('should return true for Accountant role', () => {
-      const result = AuthSelectors.selectIsAccountant.projector('Accountant');
-      expect(result).toBe(true);
-    });
-
-    it('should return false for non-Accountant role', () => {
-      const result = AuthSelectors.selectIsAccountant.projector('Admin');
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectHasRole', () => {
-    it('should return true when user has the specified role', () => {
-      const selector = AuthSelectors.selectHasRole('Admin');
-      const result = selector.projector('Admin');
-      expect(result).toBe(true);
-    });
-
-    it('should return false when user does not have the specified role', () => {
-      const selector = AuthSelectors.selectHasRole('Admin');
-      const result = selector.projector('PropertyManager');
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectHasAnyRole', () => {
-    it('should return true when user has one of the specified roles', () => {
-      const selector = AuthSelectors.selectHasAnyRole(['Admin', 'PropertyManager']);
-      const result = selector.projector('Admin');
-      expect(result).toBe(true);
-    });
-
-    it('should return false when user does not have any of the specified roles', () => {
-      const selector = AuthSelectors.selectHasAnyRole(['Admin', 'PropertyManager']);
-      const result = selector.projector('Accountant');
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectIsTokenExpired', () => {
-    it('should return false for future expiration date', () => {
-      const state = { ...mockAuthState, expiresAt: '2099-12-31T23:59:59Z' };
-      const result = AuthSelectors.selectIsTokenExpired.projector(state);
-      expect(result).toBe(false);
-    });
-
-    it('should return true for past expiration date', () => {
-      const state = { ...mockAuthState, expiresAt: '2020-01-01T00:00:00Z' };
-      const result = AuthSelectors.selectIsTokenExpired.projector(state);
-      expect(result).toBe(true);
-    });
-
-    it('should return true when expiresAt is null', () => {
-      const state = { ...mockAuthState, expiresAt: null };
-      const result = AuthSelectors.selectIsTokenExpired.projector(state);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe('selectCanViewLeases', () => {
-    it('should return true for Admin role', () => {
-      const result = AuthSelectors.selectCanViewLeases.projector('Admin');
-      expect(result).toBe(true);
-    });
-
-    it('should return true for PropertyManager role', () => {
-      const result = AuthSelectors.selectCanViewLeases.projector('PropertyManager');
-      expect(result).toBe(true);
-    });
-
-    it('should return false for Accountant role', () => {
-      const result = AuthSelectors.selectCanViewLeases.projector('Accountant');
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectCanViewAttachments', () => {
-    it('should return true for Admin role', () => {
-      const result = AuthSelectors.selectCanViewAttachments.projector('Admin');
-      expect(result).toBe(true);
-    });
-
-    it('should return true for PropertyManager role', () => {
-      const result = AuthSelectors.selectCanViewAttachments.projector('PropertyManager');
-      expect(result).toBe(true);
-    });
-
-    it('should return false for Accountant role', () => {
-      const result = AuthSelectors.selectCanViewAttachments.projector('Accountant');
+    it('should return false when role is not ORG_ADMIN', () => {
+      const result = selectIsOrgAdmin.projector('Admin');
       expect(result).toBe(false);
     });
   });
 
   describe('selectCanManageUsers', () => {
-    it('should return true for Admin role', () => {
-      const result = AuthSelectors.selectCanManageUsers.projector('Admin');
-      expect(result).toBe(true);
+    it('should return true for admin roles', () => {
+      expect(selectCanManageUsers.projector('SUPER_ADMIN')).toBe(true);
+      expect(selectCanManageUsers.projector('ORG_ADMIN')).toBe(true);
+      expect(selectCanManageUsers.projector('Admin')).toBe(true);
     });
 
-    it('should return false for PropertyManager role', () => {
-      const result = AuthSelectors.selectCanManageUsers.projector('PropertyManager');
-      expect(result).toBe(false);
+    it('should return false for non-admin roles', () => {
+      expect(selectCanManageUsers.projector('PropertyManager')).toBe(false);
+      expect(selectCanManageUsers.projector('Accountant')).toBe(false);
+    });
+  });
+
+  describe('selectCanManageOrganizations', () => {
+    it('should return true only for SUPER_ADMIN', () => {
+      expect(selectCanManageOrganizations.projector('SUPER_ADMIN')).toBe(true);
     });
 
-    it('should return false for Accountant role', () => {
-      const result = AuthSelectors.selectCanManageUsers.projector('Accountant');
-      expect(result).toBe(false);
+    it('should return false for all other roles', () => {
+      expect(selectCanManageOrganizations.projector('ORG_ADMIN')).toBe(false);
+      expect(selectCanManageOrganizations.projector('Admin')).toBe(false);
+      expect(selectCanManageOrganizations.projector('PropertyManager')).toBe(false);
+      expect(selectCanManageOrganizations.projector('Accountant')).toBe(false);
+    });
+  });
+
+  describe('selectCanInviteUsers', () => {
+    it('should return true for admin roles', () => {
+      expect(selectCanInviteUsers.projector('SUPER_ADMIN')).toBe(true);
+      expect(selectCanInviteUsers.projector('ORG_ADMIN')).toBe(true);
+      expect(selectCanInviteUsers.projector('Admin')).toBe(true);
+    });
+
+    it('should return false for non-admin roles', () => {
+      expect(selectCanInviteUsers.projector('PropertyManager')).toBe(false);
+      expect(selectCanInviteUsers.projector('Accountant')).toBe(false);
+    });
+  });
+
+  describe('Selector composition', () => {
+    it('should provide consistent results across related selectors', () => {
+      const role = 'ORG_ADMIN';
+
+      const isOrgAdminResult = selectIsOrgAdmin.projector(role);
+      const canManageUsersResult = selectCanManageUsers.projector(role);
+      const canManageOrgsResult = selectCanManageOrganizations.projector(role);
+
+      expect(isOrgAdminResult).toBe(true);
+      expect(canManageUsersResult).toBe(true);
+      expect(canManageOrgsResult).toBe(false);
+    });
+  });
+
+  describe('Permission matrix validation', () => {
+    it('should follow the permission hierarchy', () => {
+      const roles = ['SUPER_ADMIN', 'ORG_ADMIN', 'Admin'];
+
+      // All admin roles should be able to manage users
+      roles.forEach((role) => {
+        expect(selectCanManageUsers.projector(role)).toBe(true);
+      });
+
+      // Only SUPER_ADMIN should manage organizations
+      expect(selectCanManageOrganizations.projector('SUPER_ADMIN')).toBe(true);
+      roles.slice(1).forEach((role) => {
+        expect(selectCanManageOrganizations.projector(role)).toBe(false);
+      });
+    });
+
+    it('should ensure lower roles do not have admin capabilities', () => {
+      const lowerRoles = ['PropertyManager', 'Accountant'];
+
+      lowerRoles.forEach((role) => {
+        expect(selectCanManageUsers.projector(role)).toBe(false);
+        expect(selectCanManageOrganizations.projector(role)).toBe(false);
+        expect(selectCanInviteUsers.projector(role)).toBe(false);
+      });
     });
   });
 });

--- a/src/frontend/src/app/store/auth/auth.selectors.ts
+++ b/src/frontend/src/app/store/auth/auth.selectors.ts
@@ -26,6 +26,15 @@ export const selectAuthError = createSelector(selectAuthState, (state: AuthState
 
 export const selectUserRole = createSelector(selectUser, (user) => user?.role || '');
 
+export const selectUserOrganizationId = createSelector(
+  selectUser,
+  (user) => user?.organization_id || null
+);
+
+export const selectIsSuperAdmin = createSelector(selectUserRole, (role) => role === 'SUPER_ADMIN');
+
+export const selectIsOrgAdmin = createSelector(selectUserRole, (role) => role === 'ORG_ADMIN');
+
 export const selectIsAdmin = createSelector(selectUserRole, (role) => role === 'Admin');
 
 export const selectIsPropertyManager = createSelector(
@@ -56,4 +65,17 @@ export const selectCanViewAttachments = createSelector(
   (role) => role === 'Admin' || role === 'PropertyManager'
 );
 
-export const selectCanManageUsers = createSelector(selectUserRole, (role) => role === 'Admin');
+export const selectCanManageUsers = createSelector(
+  selectUserRole,
+  (role) => role === 'SUPER_ADMIN' || role === 'ORG_ADMIN' || role === 'Admin'
+);
+
+export const selectCanManageOrganizations = createSelector(
+  selectUserRole,
+  (role) => role === 'SUPER_ADMIN'
+);
+
+export const selectCanInviteUsers = createSelector(
+  selectUserRole,
+  (role) => role === 'SUPER_ADMIN' || role === 'ORG_ADMIN' || role === 'Admin'
+);

--- a/src/frontend/src/app/store/property/property.actions.ts
+++ b/src/frontend/src/app/store/property/property.actions.ts
@@ -19,7 +19,7 @@ export const loadPropertiesSuccess = createAction(
 
 export const loadPropertiesFailure = createAction(
   '[Property] Load Properties Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Load Single Property
@@ -32,7 +32,7 @@ export const loadPropertySuccess = createAction(
 
 export const loadPropertyFailure = createAction(
   '[Property] Load Property Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Load Property with Stats
@@ -48,7 +48,7 @@ export const loadPropertyWithStatsSuccess = createAction(
 
 export const loadPropertyWithStatsFailure = createAction(
   '[Property] Load Property With Stats Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Create Property
@@ -64,7 +64,7 @@ export const createPropertySuccess = createAction(
 
 export const createPropertyFailure = createAction(
   '[Property] Create Property Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Update Property
@@ -80,7 +80,7 @@ export const updatePropertySuccess = createAction(
 
 export const updatePropertyFailure = createAction(
   '[Property] Update Property Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Delete Property
@@ -93,7 +93,7 @@ export const deletePropertySuccess = createAction(
 
 export const deletePropertyFailure = createAction(
   '[Property] Delete Property Failure',
-  props<{ error: any }>()
+  props<{ error: unknown }>()
 );
 
 // Select Property

--- a/src/frontend/src/app/store/utils/common.actions.ts
+++ b/src/frontend/src/app/store/utils/common.actions.ts
@@ -11,12 +11,12 @@ export const createCrudActions = <T>(feature: string) => ({
   // Load actions
   load: createAction(`[${feature}] Load`),
   loadSuccess: createAction(`[${feature}] Load Success`, props<{ items: T[] }>()),
-  loadFailure: createAction(`[${feature}] Load Failure`, props<{ error: any }>()),
+  loadFailure: createAction(`[${feature}] Load Failure`, props<{ error: unknown }>()),
 
   // Create actions
   create: createAction(`[${feature}] Create`, props<{ item: Partial<T> }>()),
   createSuccess: createAction(`[${feature}] Create Success`, props<{ item: T }>()),
-  createFailure: createAction(`[${feature}] Create Failure`, props<{ error: any }>()),
+  createFailure: createAction(`[${feature}] Create Failure`, props<{ error: unknown }>()),
 
   // Update actions
   update: createAction(
@@ -24,12 +24,12 @@ export const createCrudActions = <T>(feature: string) => ({
     props<{ id: string | number; changes: Partial<T> }>()
   ),
   updateSuccess: createAction(`[${feature}] Update Success`, props<{ item: T }>()),
-  updateFailure: createAction(`[${feature}] Update Failure`, props<{ error: any }>()),
+  updateFailure: createAction(`[${feature}] Update Failure`, props<{ error: unknown }>()),
 
   // Delete actions
   delete: createAction(`[${feature}] Delete`, props<{ id: string | number }>()),
   deleteSuccess: createAction(`[${feature}] Delete Success`, props<{ id: string | number }>()),
-  deleteFailure: createAction(`[${feature}] Delete Failure`, props<{ error: any }>()),
+  deleteFailure: createAction(`[${feature}] Delete Failure`, props<{ error: unknown }>()),
 
   // Select actions
   select: createAction(`[${feature}] Select`, props<{ id: string | number | null }>()),

--- a/src/frontend/src/app/store/utils/entity.utils.ts
+++ b/src/frontend/src/app/store/utils/entity.utils.ts
@@ -13,7 +13,7 @@ export interface EntityState<T> {
   ids: (string | number)[];
   entities: Record<string | number, T>;
   loading: boolean;
-  error: any;
+  error: unknown;
   selectedId: string | number | null;
 }
 
@@ -31,7 +31,7 @@ export function createInitialEntityState<T>(): EntityState<T> {
 // Loading state helpers
 export interface LoadingState {
   loading: boolean;
-  error: any;
+  error: unknown;
 }
 
 export const createLoadingState = (): LoadingState => ({
@@ -51,7 +51,7 @@ export const setLoaded = <T extends LoadingState>(state: T): T => ({
   error: null,
 });
 
-export const setError = <T extends LoadingState>(state: T, error: any): T => ({
+export const setError = <T extends LoadingState>(state: T, error: unknown): T => ({
   ...state,
   loading: false,
   error,


### PR DESCRIPTION
- Add organization, user-invitation, and audit-log models
- Implement super-admin and org-admin functional route guards
- Build admin UI: organization list (CRUD), organization create form, user list with filtering
- Add /admin protected route tree with 9 child routes (organizations, invitations, audit-logs, user management)
- Update app navigation to conditionally show admin items based on user role signals

closes #50 